### PR TITLE
Performance improvement for function dirwalk.

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -249,15 +249,13 @@ func switchScene(fileName string) error {
 
 func dirwalk(dir string) (map[int]string, error) {
 	pathMap := make(map[int]string, 10)
-	r1 := regexp.MustCompile(`^map`)
-	r2 := regexp.MustCompile(`.txt$`)
 
 	i := 1
 	if err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		if !info.IsDir() && r1.MatchString(info.Name()) && r2.MatchString(info.Name()) {
+		if !info.IsDir() && strings.HasPrefix(info.Name(), "map") && strings.HasSuffix(info.Name(), ".txt") {
 			pathMap[i] = filepath.Join(dir, info.Name())
 			i++
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 
 	termbox "github.com/nsf/termbox-go"
@@ -28,5 +29,26 @@ func Test_switchScene(t *testing.T) {
 		if err := switchScene(s); err != nil {
 			t.Error(err)
 		}
+	}
+}
+
+func Test_dirwalk(t *testing.T) {
+	expected := map[int]string{
+		1:  "files/stage/map01.txt",
+		2:  "files/stage/map02.txt",
+		3:  "files/stage/map03.txt",
+		4:  "files/stage/map04.txt",
+		5:  "files/stage/map05.txt",
+		6:  "files/stage/map06.txt",
+		7:  "files/stage/map07.txt",
+		8:  "files/stage/map08.txt",
+		9:  "files/stage/map09.txt",
+		10: "files/stage/map10.txt"}
+	result, err := dirwalk(stageDir)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(expected, result) {
+		t.Error(err)
 	}
 }


### PR DESCRIPTION
### Issue
https://github.com/masahiro-kasatani/pacvim/issues/2

### Done
#### Add test code for dirwalk
- [commit](https://github.com/masahiro-kasatani/pacvim/commit/a07ed88f4251e0c6c796a155b43fc3b3a27b2bdd)
#### Change from regexp to strings
- [commit](https://github.com/masahiro-kasatani/pacvim/commit/3658180c99020fc6a275d971040942564736ffd1)
#### Run Benchmark

```go
func Benchmark_dirwalk(b *testing.B) {
	for i := 0; i < 100; i++ {
		_, _ = dirwalk(stageDir)
	}
}
```
- Before
```sh
% go test -test.bench=Benchmark_dirwalk -run=^$
goos: darwin
goarch: amd64
pkg: pacvim
cpu: Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz
Benchmark_dirwalk-8   	1000000000	         0.007149 ns/op
PASS
ok  	pacvim	0.424s
```
- After
```sh
% go test -test.bench=Benchmark_dirwalk -run=^$
goos: darwin
goarch: amd64
pkg: pacvim
cpu: Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz
Benchmark_dirwalk-8   	1000000000	         0.006761 ns/op
PASS
ok  	pacvim	0.267s
```
