### PR TITLE
feat: state/player.go の実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -481,7 +481,7 @@ make wasm         # WebAssembly ビルド（docs/wasm/ に出力）
 ### Phase 1：state パッケージ（termbox 不要・テスト可能）
 
 - [x] `state/map.go`：`Grid` / `Cell` / マップ読み込み
-- [ ] `state/player.go`：`Player` と基本コマンド（h j k l w e b 0 $ ^ gg G）
+- [x] `state/player.go`：`Player` と基本コマンド（h j k l w e b 0 $ ^ gg G）
 - [ ] `state/enemy.go`：`Enemy` / Builder / Strategy（Assault / Tricky）
 - [ ] `state/stage.go`：`Stage` とステージ定義
 - [ ] `state/gamestate.go`：`GameState.Update()`

--- a/input/input.go
+++ b/input/input.go
@@ -1,0 +1,37 @@
+// Package input はキー入力を Command 型に変換する責務を持つ。
+// Command 型は state パッケージに渡され、ebiten.Key には依存しない。
+// input.Handler による ebiten キーマッピングは Phase 2 で実装する。
+package input
+
+// Command はプレイヤーへの操作コマンドを表す。
+type Command int
+
+const (
+	CmdNone          Command = iota
+	CmdNum                  // 数字キー（0〜9、inputNum に蓄積）
+	CmdMoveLeft             // h
+	CmdMoveDown             // j
+	CmdMoveUp               // k
+	CmdMoveRight            // l
+	CmdWordForward          // w
+	CmdWordEnd              // e
+	CmdWordBack             // b
+	CmdLineBegin            // 0（単独）
+	CmdLineEnd              // $
+	CmdLineFirstWord        // ^
+	CmdFileTop              // gg
+	CmdFileBottom           // G
+	CmdFindForward          // f{char} — ch に対象文字が入る
+	CmdFindBack             // F{char}
+	CmdTillForward          // t{char}
+	CmdTillBack             // T{char}
+	CmdRepeatFind           // ;
+	CmdRepeatFindRev        // ,
+	CmdBlockForward         // }
+	CmdBlockBack            // {
+	CmdHigh                 // H
+	CmdMiddle               // M
+	CmdLow                  // L
+	CmdWordEndBack          // ge
+	CmdQuit                 // q
+)

--- a/state/player.go
+++ b/state/player.go
@@ -1,0 +1,293 @@
+package state
+
+import "github.com/masahiro-kasatani/pacvim/input"
+
+// PlayerState はプレイヤーの生死状態を表す。
+type PlayerState int
+
+const (
+	PlayerAlive PlayerState = iota
+	PlayerDead
+	PlayerWon
+)
+
+// Player はプレイヤーの状態と Vim コマンドのロジックを保持する。
+type Player struct {
+	X, Y        int
+	Score       int
+	TargetScore int
+	State       PlayerState
+	inputNum    int  // カウント蓄積（3w の "3" など）
+	inputG      bool // g 入力待ち（gg コマンド用、input.Handler で管理するため通常は未使用）
+}
+
+// Apply はコマンドをプレイヤー状態に適用する。
+// CmdNum のみ入力を蓄積してリターンし、それ以外は resetInput() で入力をリセットする。
+func (p *Player) Apply(cmd input.Command, ch rune, stage *Stage) {
+	if p.State != PlayerAlive {
+		return
+	}
+
+	switch cmd {
+	case input.CmdNum:
+		p.inputNum = p.inputNum*10 + int(ch-'0')
+		return // カウント蓄積中はリセットしない
+
+	case input.CmdMoveLeft:
+		p.applyWalk(-1, 0, stage)
+	case input.CmdMoveRight:
+		p.applyWalk(1, 0, stage)
+	case input.CmdMoveUp:
+		p.applyWalk(0, -1, stage)
+	case input.CmdMoveDown:
+		p.applyWalk(0, 1, stage)
+
+	case input.CmdWordForward:
+		p.applyWordMove(p.toBeginningOfNextWord, stage)
+	case input.CmdWordEnd:
+		p.applyWordMove(p.toEndOfCurrentWord, stage)
+	case input.CmdWordBack:
+		p.applyWordMove(p.toBeginningPrevWord, stage)
+
+	case input.CmdLineBegin:
+		p.jumpTo(p.lineBeginX(stage), p.Y, stage)
+	case input.CmdLineEnd:
+		p.jumpTo(p.lineEndX(stage), p.Y, stage)
+	case input.CmdLineFirstWord:
+		p.jumpTo(p.lineFirstWordX(stage), p.Y, stage)
+
+	case input.CmdFileTop:
+		if p.inputNum != 0 {
+			p.gotoLine(p.inputNum, stage)
+		} else {
+			p.gotoFirstLine(stage)
+		}
+	case input.CmdFileBottom:
+		if p.inputNum != 0 {
+			p.gotoLine(p.inputNum, stage)
+		} else {
+			p.gotoLastLine(stage)
+		}
+	}
+
+	p.resetInput()
+}
+
+// repeatCount はカウント入力の回数を返す。入力がなければ 1。
+func (p *Player) repeatCount() int {
+	if p.inputNum == 0 {
+		return 1
+	}
+	return p.inputNum
+}
+
+// resetInput はカウント・g 入力待ち状態をリセットする。
+func (p *Player) resetInput() {
+	p.inputNum = 0
+	p.inputG = false
+}
+
+// walkTo は現在地から (targetX, targetY) へ1ステップ移動する。
+// 移動先が歩行可能なら移動してセルを判定し true を返す。
+// 移動不可なら false を返す。
+func (p *Player) walkTo(targetX, targetY int, stage *Stage) bool {
+	if !stage.Grid.IsWalkable(targetX, targetY) {
+		return false
+	}
+	p.X = targetX
+	p.Y = targetY
+	p.checkCell(stage)
+	return true
+}
+
+// jumpTo は (targetX, targetY) へ直接ジャンプし、目的地のみ判定する。
+// 経路上の壁・敵は無視する。
+func (p *Player) jumpTo(targetX, targetY int, stage *Stage) {
+	p.X = targetX
+	p.Y = targetY
+	p.checkCell(stage)
+}
+
+// checkCell は現在地のセルを判定し、スコア加算・死亡判定を行う。
+func (p *Player) checkCell(stage *Stage) {
+	switch stage.Grid.At(p.X, p.Y).Kind {
+	case CellApple:
+		p.Score++
+		stage.Grid.Set(p.X, p.Y, CellAppleEaten)
+		if p.Score >= p.TargetScore {
+			p.State = PlayerWon
+		}
+	case CellPoison:
+		p.State = PlayerDead
+	}
+}
+
+// applyWalk は (dx, dy) 方向へ repeatCount 回 walk を繰り返す。
+func (p *Player) applyWalk(dx, dy int, stage *Stage) {
+	count := p.repeatCount()
+	for i := 0; i < count; i++ {
+		if !p.walkTo(p.X+dx, p.Y+dy, stage) {
+			break
+		}
+		if p.State != PlayerAlive {
+			break
+		}
+	}
+}
+
+// applyWordMove は word 移動関数を repeatCount 回繰り返す。
+func (p *Player) applyWordMove(fn func(*Stage) bool, stage *Stage) {
+	count := p.repeatCount()
+	for i := 0; i < count; i++ {
+		if !fn(stage) {
+			break
+		}
+		if p.State != PlayerAlive {
+			break
+		}
+	}
+}
+
+// isWordKind はセル種別がワード文字（リンゴ・収集済みリンゴ・毒）かを返す。
+// 収集済みリンゴも元のワード境界を維持するためワード文字として扱う。
+func isWordKind(k CellKind) bool {
+	return k == CellApple || k == CellAppleEaten || k == CellPoison
+}
+
+// w: 次のワードの先頭へ移動
+func (p *Player) toBeginningOfNextWord(stage *Stage) bool {
+	for {
+		seenSpace := !isWordKind(stage.Grid.At(p.X, p.Y).Kind)
+		if !p.walkTo(p.X+1, p.Y, stage) {
+			return false
+		}
+		if p.State != PlayerAlive {
+			return false
+		}
+		if seenSpace && isWordKind(stage.Grid.At(p.X, p.Y).Kind) {
+			return true
+		}
+	}
+}
+
+// b: 前のワードの先頭へ移動
+func (p *Player) toBeginningPrevWord(stage *Stage) bool {
+	// スペースを左にスキップ
+	for stage.Grid.At(p.X-1, p.Y).Kind == CellSpace {
+		if !p.walkTo(p.X-1, p.Y, stage) {
+			return false
+		}
+		if p.State != PlayerAlive {
+			return false
+		}
+	}
+	// ワード文字を左にスキップしてワード先頭へ
+	for isWordKind(stage.Grid.At(p.X-1, p.Y).Kind) {
+		if !p.walkTo(p.X-1, p.Y, stage) {
+			return false
+		}
+		if p.State != PlayerAlive {
+			return false
+		}
+	}
+	return true
+}
+
+// e: 現在のワードの末尾へ移動
+func (p *Player) toEndOfCurrentWord(stage *Stage) bool {
+	// スペースを右にスキップ
+	for stage.Grid.At(p.X+1, p.Y).Kind == CellSpace {
+		if !p.walkTo(p.X+1, p.Y, stage) {
+			return false
+		}
+		if p.State != PlayerAlive {
+			return false
+		}
+	}
+	// ワード文字を右にスキップしてワード末尾へ
+	for isWordKind(stage.Grid.At(p.X+1, p.Y).Kind) {
+		if !p.walkTo(p.X+1, p.Y, stage) {
+			return false
+		}
+		if p.State != PlayerAlive {
+			return false
+		}
+	}
+	return true
+}
+
+// lineBeginX は現在行の最も左側の歩行可能セルの x 座標を返す。
+func (p *Player) lineBeginX(stage *Stage) int {
+	for x := 0; x < stage.Grid.Width; x++ {
+		if stage.Grid.IsWalkable(x, p.Y) {
+			return x
+		}
+	}
+	return p.X
+}
+
+// lineEndX は現在行の最も右側の歩行可能セルの x 座標を返す。
+func (p *Player) lineEndX(stage *Stage) int {
+	for x := stage.Grid.Width - 1; x >= 0; x-- {
+		if stage.Grid.IsWalkable(x, p.Y) {
+			return x
+		}
+	}
+	return p.X
+}
+
+// lineFirstWordX は現在行の最初のワード文字（リンゴ・毒）の x 座標を返す。
+// ワード文字がない場合は lineBeginX にフォールバックする。
+func (p *Player) lineFirstWordX(stage *Stage) int {
+	for x := 0; x < stage.Grid.Width; x++ {
+		if isWordKind(stage.Grid.At(x, p.Y).Kind) {
+			return x
+		}
+	}
+	return p.lineBeginX(stage)
+}
+
+// rowHasContent は行 y に歩行可能なセルが存在するかを返す。
+func (p *Player) rowHasContent(y int, stage *Stage) bool {
+	for x := 0; x < stage.Grid.Width; x++ {
+		if stage.Grid.IsWalkable(x, y) {
+			return true
+		}
+	}
+	return false
+}
+
+// gotoFirstLine はコンテンツが存在する最初の行の最初のワードへジャンプする（gg）。
+func (p *Player) gotoFirstLine(stage *Stage) {
+	for y := 0; y < stage.Grid.Height; y++ {
+		if p.rowHasContent(y, stage) {
+			p.Y = y
+			p.jumpTo(p.lineFirstWordX(stage), p.Y, stage)
+			return
+		}
+	}
+}
+
+// gotoLastLine はコンテンツが存在する最後の行の最初のワードへジャンプする（G）。
+func (p *Player) gotoLastLine(stage *Stage) {
+	for y := stage.Grid.Height - 1; y >= 0; y-- {
+		if p.rowHasContent(y, stage) {
+			p.Y = y
+			p.jumpTo(p.lineFirstWordX(stage), p.Y, stage)
+			return
+		}
+	}
+}
+
+// gotoLine は n 行目（1-indexed）の最初のワードへジャンプする（Ngg / NG）。
+func (p *Player) gotoLine(n int, stage *Stage) {
+	y := n - 1
+	if y < 0 || y >= stage.Grid.Height {
+		return
+	}
+	if !p.rowHasContent(y, stage) {
+		return
+	}
+	p.Y = y
+	p.jumpTo(p.lineFirstWordX(stage), p.Y, stage)
+}

--- a/state/player_test.go
+++ b/state/player_test.go
@@ -1,0 +1,403 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/masahiro-kasatani/pacvim/input"
+)
+
+// buildGrid はテスト用の Grid を文字列スライスから生成する。
+// 文字規則は state/files/stage/*.txt と同じ（+ ! - | o X）。
+func buildGrid(rows []string) *Grid {
+	height := len(rows)
+	width := 0
+	for _, r := range rows {
+		if n := len([]rune(r)); n > width {
+			width = n
+		}
+	}
+	cells := make([][]Cell, height)
+	for i := range cells {
+		cells[i] = make([]Cell, width)
+	}
+	g := &Grid{Cells: cells, Width: width, Height: height}
+	for y, row := range rows {
+		for x, ch := range []rune(row) {
+			switch ch {
+			case '+':
+				g.Cells[y][x] = Cell{Kind: CellBoundary}
+			case '!', '-', '|':
+				g.Cells[y][x] = Cell{Kind: CellWall}
+			case 'o':
+				g.Cells[y][x] = Cell{Kind: CellApple}
+			case 'X':
+				g.Cells[y][x] = Cell{Kind: CellPoison}
+			default:
+				g.Cells[y][x] = Cell{Kind: CellSpace}
+			}
+		}
+	}
+	return g
+}
+
+func newStage(rows []string) *Stage {
+	return &Stage{Grid: buildGrid(rows)}
+}
+
+// --- h j k l（移動） ---
+
+func TestPlayerMoveRight(t *testing.T) {
+	stage := newStage([]string{
+		"+++++",
+		"+   +",
+		"+++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive}
+	p.Apply(input.CmdMoveRight, 0, stage)
+	if p.X != 2 || p.Y != 1 {
+		t.Errorf("want (2,1), got (%d,%d)", p.X, p.Y)
+	}
+}
+
+func TestPlayerMoveLeft(t *testing.T) {
+	stage := newStage([]string{
+		"+++++",
+		"+   +",
+		"+++++",
+	})
+	p := &Player{X: 3, Y: 1, State: PlayerAlive}
+	p.Apply(input.CmdMoveLeft, 0, stage)
+	if p.X != 2 || p.Y != 1 {
+		t.Errorf("want (2,1), got (%d,%d)", p.X, p.Y)
+	}
+}
+
+func TestPlayerMoveUp(t *testing.T) {
+	stage := newStage([]string{
+		"+ +",
+		"+ +",
+		"+ +",
+	})
+	p := &Player{X: 1, Y: 2, State: PlayerAlive}
+	p.Apply(input.CmdMoveUp, 0, stage)
+	if p.X != 1 || p.Y != 1 {
+		t.Errorf("want (1,1), got (%d,%d)", p.X, p.Y)
+	}
+}
+
+func TestPlayerMoveDown(t *testing.T) {
+	stage := newStage([]string{
+		"+ +",
+		"+ +",
+		"+ +",
+	})
+	p := &Player{X: 1, Y: 0, State: PlayerAlive}
+	p.Apply(input.CmdMoveDown, 0, stage)
+	if p.X != 1 || p.Y != 1 {
+		t.Errorf("want (1,1), got (%d,%d)", p.X, p.Y)
+	}
+}
+
+func TestPlayerMoveBlockedByWall(t *testing.T) {
+	stage := newStage([]string{
+		"+++++",
+		"+ ! +",
+		"+++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive}
+	p.Apply(input.CmdMoveRight, 0, stage)
+	// ! は CellWall なので移動できない
+	if p.X != 1 {
+		t.Errorf("should be blocked, got X=%d", p.X)
+	}
+}
+
+func TestPlayerMoveWithCount(t *testing.T) {
+	stage := newStage([]string{
+		"++++++++",
+		"+      +",
+		"++++++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive}
+	// 3l = 3 マス右
+	p.Apply(input.CmdNum, '3', stage)
+	p.Apply(input.CmdMoveRight, 0, stage)
+	if p.X != 4 {
+		t.Errorf("want X=4, got X=%d", p.X)
+	}
+}
+
+func TestPlayerMoveCountStopsAtWall(t *testing.T) {
+	stage := newStage([]string{
+		"+++++",
+		"+   +",
+		"+++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive}
+	// 10l = 壁手前で止まる
+	p.Apply(input.CmdNum, '1', stage)
+	p.Apply(input.CmdNum, '0', stage)
+	p.Apply(input.CmdMoveRight, 0, stage)
+	if p.X != 3 {
+		t.Errorf("want X=3 (stopped at wall), got X=%d", p.X)
+	}
+}
+
+// --- リンゴ収集・勝敗 ---
+
+func TestPlayerEatsApple(t *testing.T) {
+	stage := newStage([]string{
+		"+++++",
+		"+ o +",
+		"+++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive, TargetScore: 1}
+	p.Apply(input.CmdMoveRight, 0, stage)
+	if p.Score != 1 {
+		t.Errorf("want Score=1, got %d", p.Score)
+	}
+	if stage.Grid.At(2, 1).Kind != CellAppleEaten {
+		t.Errorf("apple should be eaten")
+	}
+}
+
+func TestPlayerWinsWhenAllApplesEaten(t *testing.T) {
+	stage := newStage([]string{
+		"+++++",
+		"+ o +",
+		"+++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive, TargetScore: 1}
+	p.Apply(input.CmdMoveRight, 0, stage)
+	if p.State != PlayerWon {
+		t.Errorf("want PlayerWon, got %v", p.State)
+	}
+}
+
+func TestPlayerDiesOnPoison(t *testing.T) {
+	stage := newStage([]string{
+		"+++++",
+		"+ X +",
+		"+++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive}
+	p.Apply(input.CmdMoveRight, 0, stage)
+	if p.State != PlayerDead {
+		t.Errorf("want PlayerDead, got %v", p.State)
+	}
+}
+
+func TestPlayerDeadIgnoresCommands(t *testing.T) {
+	stage := newStage([]string{
+		"+++++",
+		"+   +",
+		"+++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerDead}
+	p.Apply(input.CmdMoveRight, 0, stage)
+	if p.X != 1 {
+		t.Errorf("dead player should not move, got X=%d", p.X)
+	}
+}
+
+// --- w e b（ワード移動） ---
+
+func TestPlayerWordForward(t *testing.T) {
+	// "oo  oo" → w で次のワード先頭へ
+	stage := newStage([]string{
+		"++++++++",
+		"+oo  oo+",
+		"++++++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive, TargetScore: 99}
+	p.Apply(input.CmdWordForward, 0, stage)
+	if p.X != 5 {
+		t.Errorf("want X=5 (next word), got X=%d", p.X)
+	}
+}
+
+func TestPlayerWordForwardCollectsApples(t *testing.T) {
+	// w でワード内を通過するときリンゴを収集する
+	stage := newStage([]string{
+		"+++++++++",
+		"+oo   oo+",
+		"+++++++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive, TargetScore: 10}
+	p.Apply(input.CmdWordForward, 0, stage)
+	// 通過したリンゴ（x=1,x=2）は収集される
+	if p.Score < 1 {
+		t.Errorf("want apples collected during w, got Score=%d", p.Score)
+	}
+}
+
+func TestPlayerWordBack(t *testing.T) {
+	// "oo  oo" → x=6 から b で前のワード先頭へ
+	stage := newStage([]string{
+		"++++++++",
+		"+oo  oo+",
+		"++++++++",
+	})
+	p := &Player{X: 6, Y: 1, State: PlayerAlive}
+	p.Apply(input.CmdWordBack, 0, stage)
+	if p.X != 5 {
+		t.Errorf("want X=5 (prev word start), got X=%d", p.X)
+	}
+}
+
+func TestPlayerWordEnd(t *testing.T) {
+	// "oo  oo" → x=1 から e で現在ワード末尾へ
+	stage := newStage([]string{
+		"++++++++",
+		"+oo  oo+",
+		"++++++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive}
+	p.Apply(input.CmdWordEnd, 0, stage)
+	if p.X != 2 {
+		t.Errorf("want X=2 (word end), got X=%d", p.X)
+	}
+}
+
+func TestPlayerWordForwardWithCount(t *testing.T) {
+	// "oo  oo  oo" → 2w で 2番目のワード先頭へ
+	stage := newStage([]string{
+		"++++++++++++",
+		"+oo  oo  oo+",
+		"++++++++++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive, TargetScore: 99}
+	p.Apply(input.CmdNum, '2', stage)
+	p.Apply(input.CmdWordForward, 0, stage)
+	if p.X != 9 {
+		t.Errorf("want X=9 (2nd next word), got X=%d", p.X)
+	}
+}
+
+// --- 0 $ ^（行内ジャンプ） ---
+
+func TestPlayerLineBegin(t *testing.T) {
+	stage := newStage([]string{
+		"++++++++",
+		"+  ooo +",
+		"++++++++",
+	})
+	p := &Player{X: 6, Y: 1, State: PlayerAlive}
+	p.Apply(input.CmdLineBegin, 0, stage)
+	if p.X != 1 {
+		t.Errorf("want X=1 (line begin), got X=%d", p.X)
+	}
+}
+
+func TestPlayerLineEnd(t *testing.T) {
+	stage := newStage([]string{
+		"++++++++",
+		"+ ooo  +",
+		"++++++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive}
+	p.Apply(input.CmdLineEnd, 0, stage)
+	if p.X != 6 {
+		t.Errorf("want X=6 (line end), got X=%d", p.X)
+	}
+}
+
+func TestPlayerLineFirstWord(t *testing.T) {
+	// "   ooo" → ^ で最初のリンゴへ
+	stage := newStage([]string{
+		"++++++++",
+		"+   ooo+",
+		"++++++++",
+	})
+	p := &Player{X: 7, Y: 1, State: PlayerAlive}
+	p.Apply(input.CmdLineFirstWord, 0, stage)
+	if p.X != 4 {
+		t.Errorf("want X=4 (first word), got X=%d", p.X)
+	}
+}
+
+func TestPlayerLineBeginJumpsNotWalks(t *testing.T) {
+	// jump コマンドは毒を飛び越える（経路判定なし）
+	stage := newStage([]string{
+		"+++++++",
+		"+ XXXX+",
+		"+++++++",
+	})
+	p := &Player{X: 5, Y: 1, State: PlayerAlive}
+	p.Apply(input.CmdLineBegin, 0, stage)
+	// 毒を飛び越えて行先頭へ（行先頭は Space なので死なない）
+	if p.X != 1 {
+		t.Errorf("want X=1, got X=%d", p.X)
+	}
+	if p.State != PlayerAlive {
+		t.Errorf("jump should skip poison, want PlayerAlive, got %v", p.State)
+	}
+}
+
+// --- gg G（行間ジャンプ） ---
+
+func TestPlayerFileTop(t *testing.T) {
+	stage := newStage([]string{
+		"+++++",
+		"+ooo+",
+		"+ooo+",
+		"+++++",
+	})
+	p := &Player{X: 1, Y: 2, State: PlayerAlive}
+	p.Apply(input.CmdFileTop, 0, stage)
+	if p.Y != 1 {
+		t.Errorf("want Y=1 (first line), got Y=%d", p.Y)
+	}
+	// 行の最初のワード文字へジャンプ
+	if p.X != 1 {
+		t.Errorf("want X=1 (first word), got X=%d", p.X)
+	}
+}
+
+func TestPlayerFileBottom(t *testing.T) {
+	stage := newStage([]string{
+		"+++++",
+		"+ooo+",
+		"+ooo+",
+		"+++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive}
+	p.Apply(input.CmdFileBottom, 0, stage)
+	if p.Y != 2 {
+		t.Errorf("want Y=2 (last line), got Y=%d", p.Y)
+	}
+}
+
+func TestPlayerFileTopWithCount(t *testing.T) {
+	// 2gg = 2行目へ（1-indexed）
+	stage := newStage([]string{
+		"+++++",
+		"+ooo+",
+		"+ooo+",
+		"+ooo+",
+		"+++++",
+	})
+	p := &Player{X: 1, Y: 3, State: PlayerAlive}
+	p.Apply(input.CmdNum, '2', stage)
+	p.Apply(input.CmdFileTop, 0, stage)
+	if p.Y != 1 {
+		t.Errorf("want Y=1 (line 2), got Y=%d", p.Y)
+	}
+}
+
+func TestPlayerFileBottomWithCount(t *testing.T) {
+	// 3G = 3行目へ（1-indexed）
+	stage := newStage([]string{
+		"+++++",
+		"+ooo+",
+		"+ooo+",
+		"+ooo+",
+		"+++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive}
+	p.Apply(input.CmdNum, '3', stage)
+	p.Apply(input.CmdFileBottom, 0, stage)
+	if p.Y != 2 {
+		t.Errorf("want Y=2 (line 3), got Y=%d", p.Y)
+	}
+}

--- a/state/stage.go
+++ b/state/stage.go
@@ -1,0 +1,12 @@
+package state
+
+import "time"
+
+// Stage は1ステージの設定を保持する。
+// HunterConfig / GhostConfig は state/enemy.go 実装時に追加する。
+type Stage struct {
+	Level     int
+	MapPath   string
+	Grid      *Grid
+	GameSpeed time.Duration
+}


### PR DESCRIPTION
## Summary

- `input/input.go`：`Command` 型と全定数を定義（`Handler` による ebiten キーマッピングは Phase 2 で実装）
- `state/stage.go`：`Stage` struct を最小構成で定義（`enemy.go` 実装時に `HunterConfig` / `GhostConfig` を追加）
- `state/player.go`：`Player` struct と基本コマンド（h j k l w e b 0 $ ^ gg G）を実装
  - `walkTo`：経路上の全セルを判定（リンゴ収集・毒死亡）
  - `jumpTo`：目的地のみ判定（経路上の壁・毒は無視）
  - `applyWalk` / `applyWordMove` でカウント入力（`3l`・`2w` 等）に対応
- `state/player_test.go`：移動・リンゴ収集・勝敗・ワード移動・行内外ジャンプのテスト

## go test ./state/... -v

```
=== RUN   TestGridAt_OutOfBounds
--- PASS: TestGridAt_OutOfBounds (0.00s)
=== RUN   TestGridAt_InBounds
--- PASS: TestGridAt_InBounds (0.00s)
=== RUN   TestGridIsWalkable
--- PASS: TestGridIsWalkable (0.00s)
=== RUN   TestLoadGrid_Map01
--- PASS: TestLoadGrid_Map01 (0.00s)
=== RUN   TestPlayerMoveRight
--- PASS: TestPlayerMoveRight (0.00s)
=== RUN   TestPlayerMoveLeft
--- PASS: TestPlayerMoveLeft (0.00s)
=== RUN   TestPlayerMoveUp
--- PASS: TestPlayerMoveUp (0.00s)
=== RUN   TestPlayerMoveDown
--- PASS: TestPlayerMoveDown (0.00s)
=== RUN   TestPlayerMoveBlockedByWall
--- PASS: TestPlayerMoveBlockedByWall (0.00s)
=== RUN   TestPlayerMoveWithCount
--- PASS: TestPlayerMoveWithCount (0.00s)
=== RUN   TestPlayerMoveCountStopsAtWall
--- PASS: TestPlayerMoveCountStopsAtWall (0.00s)
=== RUN   TestPlayerEatsApple
--- PASS: TestPlayerEatsApple (0.00s)
=== RUN   TestPlayerWinsWhenAllApplesEaten
--- PASS: TestPlayerWinsWhenAllApplesEaten (0.00s)
=== RUN   TestPlayerDiesOnPoison
--- PASS: TestPlayerDiesOnPoison (0.00s)
=== RUN   TestPlayerDeadIgnoresCommands
--- PASS: TestPlayerDeadIgnoresCommands (0.00s)
=== RUN   TestPlayerWordForward
--- PASS: TestPlayerWordForward (0.00s)
=== RUN   TestPlayerWordForwardCollectsApples
--- PASS: TestPlayerWordForwardCollectsApples (0.00s)
=== RUN   TestPlayerWordBack
--- PASS: TestPlayerWordBack (0.00s)
=== RUN   TestPlayerWordEnd
--- PASS: TestPlayerWordEnd (0.00s)
=== RUN   TestPlayerWordForwardWithCount
--- PASS: TestPlayerWordForwardWithCount (0.00s)
=== RUN   TestPlayerLineBegin
--- PASS: TestPlayerLineBegin (0.00s)
=== RUN   TestPlayerLineEnd
--- PASS: TestPlayerLineEnd (0.00s)
=== RUN   TestPlayerLineFirstWord
--- PASS: TestPlayerLineFirstWord (0.00s)
=== RUN   TestPlayerLineBeginJumpsNotWalks
--- PASS: TestPlayerLineBeginJumpsNotWalks (0.00s)
=== RUN   TestPlayerFileTop
--- PASS: TestPlayerFileTop (0.00s)
=== RUN   TestPlayerFileBottom
--- PASS: TestPlayerFileBottom (0.00s)
=== RUN   TestPlayerFileTopWithCount
--- PASS: TestPlayerFileTopWithCount (0.00s)
=== RUN   TestPlayerFileBottomWithCount
--- PASS: TestPlayerFileBottomWithCount (0.00s)
PASS
ok  	github.com/masahiro-kasatani/pacvim/state	0.328s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)