### PR TITLE
feat: state/gamestate.go — GameState.Update() + tests

### DIFF
--- a/state/gamestate.go
+++ b/state/gamestate.go
@@ -1,0 +1,195 @@
+package state
+
+import (
+	"errors"
+	"time"
+
+	"github.com/masahiro-kasatani/pacvim/input"
+)
+
+// ErrQuit はプレイヤーが q でゲームを終了したときに返す番兵エラー。
+var ErrQuit = errors.New("quit")
+
+// GamePhase はゲームの進行フェーズを表す。
+type GamePhase int
+
+const (
+	PhaseOpening   GamePhase = iota // 開幕画面（最初のキー入力待ち）
+	PhasePlaying                    // プレイ中
+	PhaseStageClear                 // ステージクリア
+	PhaseGameOver                   // ゲームオーバー
+	PhaseGameClear                  // 全ステージクリア
+)
+
+// GameState はゲーム全体の状態を保持する。
+type GameState struct {
+	Stages    []Stage
+	StageIdx  int
+	Player    *Player
+	Enemies   []Enemy
+	Life      int
+	EnemyTick int
+	Phase     GamePhase
+}
+
+// NewGameState は初期状態の GameState を生成する。
+// life には初期ライフ数を指定する。
+func NewGameState(life int) (*GameState, error) {
+	stages := InitStages()
+	gs := &GameState{
+		Stages:   stages,
+		Life:     life,
+		Phase:    PhaseOpening,
+	}
+	if err := gs.loadStage(); err != nil {
+		return nil, err
+	}
+	return gs, nil
+}
+
+// Stage は現在のステージを返す。
+func (gs *GameState) Stage() *Stage {
+	return &gs.Stages[gs.StageIdx]
+}
+
+// loadStage は現在のステージを読み込み、Player と Enemies を初期化する。
+func (gs *GameState) loadStage() error {
+	stage := gs.Stage()
+	spawns, err := stage.Load()
+	if err != nil {
+		return err
+	}
+
+	apples := countApples(stage.Grid)
+	gs.Player = &Player{
+		X:           spawns.Player.X,
+		Y:           spawns.Player.Y,
+		State:       PlayerAlive,
+		TargetScore: apples,
+	}
+
+	enemies := make([]Enemy, 0, len(spawns.Hunters)+len(spawns.Ghosts))
+	for _, sp := range spawns.Hunters {
+		enemies = append(enemies, stage.HunterConfig.Build(sp.X, sp.Y))
+	}
+	if stage.GhostConfig != nil {
+		for _, sp := range spawns.Ghosts {
+			enemies = append(enemies, stage.GhostConfig.Build(sp.X, sp.Y))
+		}
+	}
+	gs.Enemies = enemies
+	gs.EnemyTick = 0
+	return nil
+}
+
+// countApples はグリッド上のリンゴの数を数える。
+func countApples(grid *Grid) int {
+	count := 0
+	for y := 0; y < grid.Height; y++ {
+		for x := 0; x < grid.Width; x++ {
+			if grid.At(x, y).Kind == CellApple {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+// Update は1フレーム分のゲーム状態を更新する。
+// q キーで ErrQuit を返す。
+func (gs *GameState) Update(cmd input.Command, ch rune) error {
+	if cmd == input.CmdQuit {
+		return ErrQuit
+	}
+
+	switch gs.Phase {
+	case PhaseOpening:
+		gs.updateOpening(cmd, ch)
+	case PhasePlaying:
+		gs.updatePlaying(cmd, ch)
+	}
+	return nil
+}
+
+// updateOpening はオープニング画面の更新処理。
+// CmdNone 以外のコマンドが来たらゲームを開始する。
+func (gs *GameState) updateOpening(cmd input.Command, ch rune) {
+	if cmd != input.CmdNone {
+		gs.Phase = PhasePlaying
+		gs.updatePlaying(cmd, ch)
+	}
+}
+
+// updatePlaying はプレイ中の更新処理。
+func (gs *GameState) updatePlaying(cmd input.Command, ch rune) {
+	gs.Player.Apply(cmd, ch, gs.Stage())
+
+	gs.checkEnemyCapture()
+	if gs.Phase != PhasePlaying {
+		return
+	}
+
+	gs.advanceEnemyTick()
+	gs.checkEnemyCapture()
+	if gs.Phase != PhasePlaying {
+		return
+	}
+
+	switch gs.Player.State {
+	case PlayerWon:
+		gs.handleStageClear()
+	case PlayerDead:
+		gs.handlePlayerDeath()
+	}
+}
+
+// advanceEnemyTick は EnemyTick を進め、GameSpeed に達したら敵を移動させる。
+func (gs *GameState) advanceEnemyTick() {
+	gs.EnemyTick++
+	if time.Duration(gs.EnemyTick)*(time.Second/60) >= gs.Stage().GameSpeed {
+		gs.moveEnemies()
+		gs.EnemyTick = 0
+	}
+}
+
+// moveEnemies は全敵を1ステップ移動させる。
+func (gs *GameState) moveEnemies() {
+	for _, e := range gs.Enemies {
+		nx, ny := e.Think(gs.Player, gs.Stage().Grid)
+		e.Move(nx, ny, gs.Stage().Grid)
+	}
+}
+
+// checkEnemyCapture はいずれかの敵がプレイヤーを捕獲しているか確認する。
+// 捕獲されていた場合は handlePlayerDeath を呼ぶ。
+func (gs *GameState) checkEnemyCapture() {
+	for _, e := range gs.Enemies {
+		if e.HasCaptured(gs.Player) {
+			gs.Player.State = PlayerDead
+			gs.handlePlayerDeath()
+			return
+		}
+	}
+}
+
+// handleStageClear はステージクリア時の処理を行う。
+func (gs *GameState) handleStageClear() {
+	if gs.StageIdx+1 < len(gs.Stages) {
+		gs.StageIdx++
+		_ = gs.loadStage()
+		gs.Phase = PhasePlaying
+	} else {
+		gs.Phase = PhaseGameClear
+	}
+}
+
+// handlePlayerDeath はプレイヤー死亡時の処理を行う。
+func (gs *GameState) handlePlayerDeath() {
+	gs.Life--
+	if gs.Life <= 0 {
+		gs.Phase = PhaseGameOver
+	} else {
+		_ = gs.loadStage()
+		gs.Phase = PhasePlaying
+	}
+}

--- a/state/gamestate_test.go
+++ b/state/gamestate_test.go
@@ -1,0 +1,304 @@
+package state
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/masahiro-kasatani/pacvim/input"
+)
+
+// --- NewGameState ---
+
+func TestNewGameState(t *testing.T) {
+	gs, err := NewGameState(3)
+	if err != nil {
+		t.Fatalf("NewGameState failed: %v", err)
+	}
+	if gs.Life != 3 {
+		t.Errorf("want Life=3, got %d", gs.Life)
+	}
+	if gs.Phase != PhaseOpening {
+		t.Errorf("want PhaseOpening, got %v", gs.Phase)
+	}
+	if gs.StageIdx != 0 {
+		t.Errorf("want StageIdx=0, got %d", gs.StageIdx)
+	}
+	if gs.Player == nil {
+		t.Fatal("Player should not be nil")
+	}
+	if gs.Stage().Grid == nil {
+		t.Fatal("Stage Grid should be loaded")
+	}
+}
+
+func TestNewGameStatePlayerTargetScore(t *testing.T) {
+	gs, err := NewGameState(3)
+	if err != nil {
+		t.Fatalf("NewGameState failed: %v", err)
+	}
+	if gs.Player.TargetScore <= 0 {
+		t.Errorf("TargetScore should be positive, got %d", gs.Player.TargetScore)
+	}
+}
+
+func TestNewGameStateEnemiesSpawned(t *testing.T) {
+	gs, err := NewGameState(3)
+	if err != nil {
+		t.Fatalf("NewGameState failed: %v", err)
+	}
+	// map01.txt には2体のハンターがいる
+	if len(gs.Enemies) != 2 {
+		t.Errorf("want 2 enemies, got %d", len(gs.Enemies))
+	}
+}
+
+// --- countApples ---
+
+func TestCountApples(t *testing.T) {
+	grid := buildGrid([]string{
+		"+++++",
+		"+ooo+",
+		"+++++",
+	})
+	if n := countApples(grid); n != 3 {
+		t.Errorf("want 3 apples, got %d", n)
+	}
+}
+
+func TestCountApplesEmpty(t *testing.T) {
+	grid := buildGrid([]string{
+		"+++++",
+		"+   +",
+		"+++++",
+	})
+	if n := countApples(grid); n != 0 {
+		t.Errorf("want 0 apples, got %d", n)
+	}
+}
+
+// --- ErrQuit ---
+
+func TestUpdateQuit(t *testing.T) {
+	gs, err := NewGameState(3)
+	if err != nil {
+		t.Fatalf("NewGameState failed: %v", err)
+	}
+	err = gs.Update(input.CmdQuit, 0)
+	if !errors.Is(err, ErrQuit) {
+		t.Errorf("want ErrQuit, got %v", err)
+	}
+}
+
+// --- PhaseOpening ---
+
+func TestUpdateOpeningIgnoresCmdNone(t *testing.T) {
+	gs, err := NewGameState(3)
+	if err != nil {
+		t.Fatalf("NewGameState failed: %v", err)
+	}
+	_ = gs.Update(input.CmdNone, 0)
+	if gs.Phase != PhaseOpening {
+		t.Errorf("CmdNone should keep PhaseOpening, got %v", gs.Phase)
+	}
+}
+
+func TestUpdateOpeningStartsOnCommand(t *testing.T) {
+	gs, err := NewGameState(3)
+	if err != nil {
+		t.Fatalf("NewGameState failed: %v", err)
+	}
+	_ = gs.Update(input.CmdMoveRight, 0)
+	if gs.Phase != PhasePlaying {
+		t.Errorf("command should transition to PhasePlaying, got %v", gs.Phase)
+	}
+}
+
+// --- EnemyTick ---
+
+func TestEnemyTickAdvances(t *testing.T) {
+	gs, err := NewGameState(3)
+	if err != nil {
+		t.Fatalf("NewGameState failed: %v", err)
+	}
+	gs.Phase = PhasePlaying
+	_ = gs.Update(input.CmdNone, 0)
+	if gs.EnemyTick != 1 {
+		t.Errorf("want EnemyTick=1, got %d", gs.EnemyTick)
+	}
+}
+
+func TestEnemyTickResetsAfterGameSpeed(t *testing.T) {
+	gs, err := NewGameState(3)
+	if err != nil {
+		t.Fatalf("NewGameState failed: %v", err)
+	}
+	gs.Phase = PhasePlaying
+	// GameSpeed を 1 フレーム相当に設定して強制リセット
+	gs.Stages[0].GameSpeed = time.Second / 60
+	_ = gs.Update(input.CmdNone, 0)
+	if gs.EnemyTick != 0 {
+		t.Errorf("EnemyTick should reset after GameSpeed reached, got %d", gs.EnemyTick)
+	}
+}
+
+// --- 敵キャプチャ → 死亡・ライフ減少 ---
+
+func TestEnemyCaptureReducesLife(t *testing.T) {
+	gs := newGameStateWithGrid([]string{
+		"+++++",
+		"+   +",
+		"+++++",
+	}, 3)
+	// 敵をプレイヤーと同じ位置に配置
+	gs.Enemies = []Enemy{NewHunterBuilder().Build(gs.Player.X, gs.Player.Y)}
+	gs.Phase = PhasePlaying
+
+	_ = gs.Update(input.CmdNone, 0)
+	if gs.Life != 2 {
+		t.Errorf("want Life=2 after capture, got %d", gs.Life)
+	}
+}
+
+func TestEnemyCaptureResetsStage(t *testing.T) {
+	gs := newGameStateWithGrid([]string{
+		"+++++",
+		"+ooo+",
+		"+++++",
+	}, 3)
+	gs.Enemies = []Enemy{NewHunterBuilder().Build(gs.Player.X, gs.Player.Y)}
+	gs.Phase = PhasePlaying
+	initialScore := gs.Player.Score
+
+	_ = gs.Update(input.CmdNone, 0)
+	// ステージリセット後はスコアが 0 に戻っている
+	if gs.Player.Score != initialScore {
+		t.Errorf("score should reset after stage reload, got %d", gs.Player.Score)
+	}
+}
+
+func TestEnemyCaptureGameOverWhenNoLife(t *testing.T) {
+	gs := newGameStateWithGrid([]string{
+		"+++++",
+		"+   +",
+		"+++++",
+	}, 1)
+	gs.Enemies = []Enemy{NewHunterBuilder().Build(gs.Player.X, gs.Player.Y)}
+	gs.Phase = PhasePlaying
+
+	_ = gs.Update(input.CmdNone, 0)
+	if gs.Phase != PhaseGameOver {
+		t.Errorf("want PhaseGameOver, got %v", gs.Phase)
+	}
+}
+
+// --- 毒 → 死亡 ---
+
+func TestPoisonKillsPlayer(t *testing.T) {
+	gs := newGameStateWithGrid([]string{
+		"++++++",
+		"+  X +",
+		"++++++",
+	}, 3)
+	gs.Phase = PhasePlaying
+	gs.Player.X = 2
+	gs.Player.Y = 1
+
+	_ = gs.Update(input.CmdMoveRight, 0)
+	// 毒(3,1)に踏み込んで死亡 → ライフ減少
+	if gs.Life != 2 {
+		t.Errorf("want Life=2 after poison, got %d", gs.Life)
+	}
+}
+
+// --- ステージクリア ---
+
+func TestStageClearAdvancesStage(t *testing.T) {
+	gs := newGameStateWithGrid([]string{
+		"+++++",
+		"+  o+",
+		"+++++",
+	}, 3)
+	gs.Player.X = 2
+	gs.Player.Y = 1
+	gs.Player.TargetScore = 1
+	gs.Phase = PhasePlaying
+
+	// リンゴ(3,1)へ移動してステージクリア
+	_ = gs.Update(input.CmdMoveRight, 0)
+	if gs.StageIdx != 1 {
+		t.Errorf("want StageIdx=1 after clear, got %d", gs.StageIdx)
+	}
+	if gs.Phase != PhasePlaying {
+		t.Errorf("want PhasePlaying after stage clear, got %v", gs.Phase)
+	}
+}
+
+func TestGameClearOnLastStage(t *testing.T) {
+	grid := buildGrid([]string{
+		"+++++",
+		"+  o+",
+		"+++++",
+	})
+	apples := countApples(grid)
+	stages := InitStages()
+	lastIdx := len(stages) - 1
+	// 最終ステージのグリッドをテスト用に差し替え
+	stages[lastIdx].Grid = grid
+	gs := &GameState{
+		Stages:   stages,
+		StageIdx: lastIdx,
+		Player: &Player{
+			X:           2,
+			Y:           1,
+			State:       PlayerAlive,
+			TargetScore: apples,
+		},
+		Enemies: []Enemy{},
+		Life:    3,
+		Phase:   PhasePlaying,
+	}
+
+	_ = gs.Update(input.CmdMoveRight, 0)
+	if gs.Phase != PhaseGameClear {
+		t.Errorf("want PhaseGameClear after last stage, got %v", gs.Phase)
+	}
+}
+
+// --- Stage() アクセサ ---
+
+func TestStageAccessor(t *testing.T) {
+	gs, err := NewGameState(3)
+	if err != nil {
+		t.Fatalf("NewGameState failed: %v", err)
+	}
+	if gs.Stage() != &gs.Stages[0] {
+		t.Error("Stage() should return pointer to current stage")
+	}
+}
+
+// --- ヘルパー ---
+
+// newGameStateWithGrid はテスト用のカスタムグリッドを持つ GameState を構築する。
+// マップファイルは使わず Stage のグリッドを直接差し替える。
+func newGameStateWithGrid(rows []string, life int) *GameState {
+	grid := buildGrid(rows)
+	apples := countApples(grid)
+	player := &Player{
+		X:           1,
+		Y:           1,
+		State:       PlayerAlive,
+		TargetScore: apples,
+	}
+	stages := InitStages()
+	// ステージ0のグリッドを差し替え（ファイル読み込みなし）
+	stages[0].Grid = grid
+	return &GameState{
+		Stages:   stages,
+		StageIdx: 0,
+		Player:   player,
+		Enemies:  []Enemy{},
+		Life:     life,
+		Phase:    PhasePlaying,
+	}
+}


### PR DESCRIPTION
## Summary
- `state/gamestate.go`: `GameState` struct、`GamePhase` 型、`NewGameState`コンストラクタ、`Update()` ループを実装
- `state/gamestate_test.go`: フェーズ遷移・敵キャプチャ・ライフ管理・ステージ進行のユニットテスト

## 設計のポイント
- `PhaseOpening` → `PhasePlaying`: CmdNone 以外の最初のキー入力でゲーム開始
- `EnemyTick` で `GameSpeed` を TPS=60 固定のフレームカウンタに変換して敵移動タイミングを制御
- `ErrQuit` 番兵エラーで `q` キーの終了を `ebiten` なしに通知
- `loadStage()` がステージリセット（死亡・クリア後）を統一処理

## Test plan
- [x] `go test ./state/...` すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)