### PR TITLE
feat: add ebiten/v2 and implement input.Handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,16 +1,22 @@
 module github.com/masahiro-kasatani/pacvim
 
-go 1.20
+go 1.24.0
 
 require (
 	github.com/nsf/termbox-go v1.1.1
 	github.com/stretchr/testify v1.8.2
-	golang.org/x/sync v0.1.0
+	golang.org/x/sync v0.17.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/ebitengine/gomobile v0.0.0-20250923094054-ea854a63cce1 // indirect
+	github.com/ebitengine/hideconsole v1.0.0 // indirect
+	github.com/ebitengine/purego v0.9.0 // indirect
+	github.com/hajimehoshi/ebiten/v2 v2.9.9 // indirect
+	github.com/jezek/xgb v1.1.1 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.36.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,16 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/ebitengine/gomobile v0.0.0-20250923094054-ea854a63cce1 h1:+kz5iTT3L7uU+VhlMfTb8hHcxLO3TlaELlX8wa4XjA0=
+github.com/ebitengine/gomobile v0.0.0-20250923094054-ea854a63cce1/go.mod h1:lKJoeixeJwnFmYsBny4vvCJGVFc3aYDalhuDsfZzWHI=
+github.com/ebitengine/hideconsole v1.0.0 h1:5J4U0kXF+pv/DhiXt5/lTz0eO5ogJ1iXb8Yj1yReDqE=
+github.com/ebitengine/hideconsole v1.0.0/go.mod h1:hTTBTvVYWKBuxPr7peweneWdkUwEuHuB3C1R/ielR1A=
+github.com/ebitengine/purego v0.9.0 h1:mh0zpKBIXDceC63hpvPuGLiJ8ZAa3DfrFTudmfi8A4k=
+github.com/ebitengine/purego v0.9.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/hajimehoshi/ebiten/v2 v2.9.9 h1:JdDag6Ndj12iD4lxQGG8kbsrh7ssj4Sbzth6r929H/M=
+github.com/hajimehoshi/ebiten/v2 v2.9.9/go.mod h1:DAt4tnkYYpCvu3x9i1X/nK/vOruNXIlYq/tBXxnhrXM=
+github.com/jezek/xgb v1.1.1 h1:bE/r8ZZtSv7l9gk6nU0mYx51aXrvnyb44892TwSaqS4=
+github.com/jezek/xgb v1.1.1/go.mod h1:nrhwO0FX/enq75I7Y7G8iN1ubpSGZEiA3v9e9GyRFlk=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/nsf/termbox-go v1.1.1 h1:nksUPLCb73Q++DwbYUBEglYBRPZyoXJdrj5L+TkjyZY=
@@ -16,6 +26,10 @@ github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
+golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
+golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/input/input.go
+++ b/input/input.go
@@ -1,7 +1,11 @@
 // Package input はキー入力を Command 型に変換する責務を持つ。
-// Command 型は state パッケージに渡され、ebiten.Key には依存しない。
-// input.Handler による ebiten キーマッピングは Phase 2 で実装する。
+// Command 型は state パッケージに渡される。ebiten.Key への依存はこのパッケージに閉じる。
 package input
+
+import (
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/inpututil"
+)
 
 // Command はプレイヤーへの操作コマンドを表す。
 type Command int
@@ -21,7 +25,7 @@ const (
 	CmdLineFirstWord        // ^
 	CmdFileTop              // gg
 	CmdFileBottom           // G
-	CmdFindForward          // f{char} — ch に対象文字が入る
+	CmdFindForward          // f{char}
 	CmdFindBack             // F{char}
 	CmdTillForward          // t{char}
 	CmdTillBack             // T{char}
@@ -35,3 +39,135 @@ const (
 	CmdWordEndBack          // ge
 	CmdQuit                 // q
 )
+
+// Handler はキー入力を毎フレーム読み取り Command に変換する。
+// 2ストロークコマンド（gg, ge, f/t）の状態はここで管理する。
+type Handler struct {
+	prevG      bool    // g を受け取った後、次のキーを待つ
+	awaitChar  bool    // f/F/t/T の後、対象文字を待つ
+	pendingCmd Command // awaitChar 中の保留コマンド
+	inNumMode  bool    // 数字蓄積中かどうか（0 の振り分けに使用）
+}
+
+// Read は1フレーム分のキー入力を読み取り、(Command, rune) を返す。
+// CmdNum のとき rune は押された数字文字。
+// CmdFindForward/Back/TillForward/Back のとき rune は対象文字。
+// それ以外の場合 rune は 0。
+func (h *Handler) Read() (Command, rune) {
+	// awaitChar モード: f/F/t/T の対象文字を待つ
+	if h.awaitChar {
+		chars := ebiten.AppendInputChars(nil)
+		if len(chars) > 0 {
+			cmd := h.pendingCmd
+			h.awaitChar = false
+			h.pendingCmd = CmdNone
+			h.inNumMode = false
+			return cmd, chars[0]
+		}
+		return CmdNone, 0
+	}
+
+	shift := ebiten.IsKeyPressed(ebiten.KeyShiftLeft) || ebiten.IsKeyPressed(ebiten.KeyShiftRight)
+
+	// prevG モード: gg または ge の2文字目を待つ
+	if h.prevG {
+		if !shift && inpututil.IsKeyJustPressed(ebiten.KeyG) {
+			h.prevG = false
+			h.inNumMode = false
+			return CmdFileTop, 0
+		}
+		if !shift && inpututil.IsKeyJustPressed(ebiten.KeyE) {
+			h.prevG = false
+			h.inNumMode = false
+			return CmdWordEndBack, 0
+		}
+		return CmdNone, 0
+	}
+
+	// 数字キー（1〜9 は常に CmdNum）
+	digits := []ebiten.Key{
+		ebiten.Key1, ebiten.Key2, ebiten.Key3, ebiten.Key4, ebiten.Key5,
+		ebiten.Key6, ebiten.Key7, ebiten.Key8, ebiten.Key9,
+	}
+	for i, k := range digits {
+		if !shift && inpututil.IsKeyJustPressed(k) {
+			h.inNumMode = true
+			return CmdNum, rune('1' + i)
+		}
+	}
+	// 0: 数字蓄積中なら CmdNum、単独なら CmdLineBegin
+	if !shift && inpututil.IsKeyJustPressed(ebiten.Key0) {
+		if h.inNumMode {
+			return CmdNum, '0'
+		}
+		return CmdLineBegin, 0
+	}
+
+	// 以降のコマンドは数字蓄積をリセット
+	h.inNumMode = false
+
+	if shift {
+		switch {
+		case inpututil.IsKeyJustPressed(ebiten.KeyG):
+			return CmdFileBottom, 0
+		case inpututil.IsKeyJustPressed(ebiten.KeyH):
+			return CmdHigh, 0
+		case inpututil.IsKeyJustPressed(ebiten.KeyM):
+			return CmdMiddle, 0
+		case inpututil.IsKeyJustPressed(ebiten.KeyL):
+			return CmdLow, 0
+		case inpututil.IsKeyJustPressed(ebiten.KeyF):
+			h.awaitChar = true
+			h.pendingCmd = CmdFindBack
+			return CmdNone, 0
+		case inpututil.IsKeyJustPressed(ebiten.KeyT):
+			h.awaitChar = true
+			h.pendingCmd = CmdTillBack
+			return CmdNone, 0
+		case inpututil.IsKeyJustPressed(ebiten.Key4): // $
+			return CmdLineEnd, 0
+		case inpututil.IsKeyJustPressed(ebiten.Key6): // ^
+			return CmdLineFirstWord, 0
+		case inpututil.IsKeyJustPressed(ebiten.KeyLeftBracket): // {
+			return CmdBlockBack, 0
+		case inpututil.IsKeyJustPressed(ebiten.KeyRightBracket): // }
+			return CmdBlockForward, 0
+		}
+	} else {
+		switch {
+		case inpututil.IsKeyJustPressed(ebiten.KeyH):
+			return CmdMoveLeft, 0
+		case inpututil.IsKeyJustPressed(ebiten.KeyJ):
+			return CmdMoveDown, 0
+		case inpututil.IsKeyJustPressed(ebiten.KeyK):
+			return CmdMoveUp, 0
+		case inpututil.IsKeyJustPressed(ebiten.KeyL):
+			return CmdMoveRight, 0
+		case inpututil.IsKeyJustPressed(ebiten.KeyW):
+			return CmdWordForward, 0
+		case inpututil.IsKeyJustPressed(ebiten.KeyE):
+			return CmdWordEnd, 0
+		case inpututil.IsKeyJustPressed(ebiten.KeyB):
+			return CmdWordBack, 0
+		case inpututil.IsKeyJustPressed(ebiten.KeyG):
+			h.prevG = true
+			return CmdNone, 0
+		case inpututil.IsKeyJustPressed(ebiten.KeyF):
+			h.awaitChar = true
+			h.pendingCmd = CmdFindForward
+			return CmdNone, 0
+		case inpututil.IsKeyJustPressed(ebiten.KeyT):
+			h.awaitChar = true
+			h.pendingCmd = CmdTillForward
+			return CmdNone, 0
+		case inpututil.IsKeyJustPressed(ebiten.KeySemicolon):
+			return CmdRepeatFind, 0
+		case inpututil.IsKeyJustPressed(ebiten.KeyComma):
+			return CmdRepeatFindRev, 0
+		case inpututil.IsKeyJustPressed(ebiten.KeyQ):
+			return CmdQuit, 0
+		}
+	}
+
+	return CmdNone, 0
+}


### PR DESCRIPTION
## Summary
- `go.mod`: `github.com/hajimehoshi/ebiten/v2 v2.9.9` を追加
- `input/input.go`: `Handler` を実装（キー入力 → `Command` 変換）

## Handler の設計
- **2ストロークコマンド**: `gg`/`ge`（`prevG` フラグ）、`f/F/t/T`（`awaitChar` フラグ + `ebiten.AppendInputChars`）
- **`0` の振り分け**: 数字蓄積中（`inNumMode=true`）なら `CmdNum`、単独なら `CmdLineBegin`
- **Shift 判定**: `KeyShiftLeft || KeyShiftRight` で大文字コマンド（H/M/L/G/$/{/}）を区別

## Test plan
- [x] `go test ./state/... ./input/...` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)