### PR TITLE
fix: エネミー同士の重複移動を防ぐ

### DIFF
--- a/state/gamestate.go
+++ b/state/gamestate.go
@@ -153,10 +153,40 @@ func (gs *GameState) advanceEnemyTick() {
 }
 
 // moveEnemies は全敵を1ステップ移動させる。
+// 移動先が他の敵の現在地または他の敵の移動先と重複する場合は移動しない。
+// インデックスが小さい敵が優先される。
 func (gs *GameState) moveEnemies() {
-	for _, e := range gs.Enemies {
-		nx, ny := e.Think(gs.Player, gs.Stage().Grid)
-		e.Move(nx, ny, gs.Stage().Grid)
+	grid := gs.Stage().Grid
+
+	// 全員の移動先を先に決定する
+	targets := make([][2]int, len(gs.Enemies))
+	for i, e := range gs.Enemies {
+		nx, ny := e.Think(gs.Player, grid)
+		targets[i] = [2]int{nx, ny}
+	}
+
+	for i, e := range gs.Enemies {
+		nx, ny := targets[i][0], targets[i][1]
+		conflict := false
+		for j, other := range gs.Enemies {
+			if i == j {
+				continue
+			}
+			// 他の敵の現在地と重複
+			ox, oy := other.Position()
+			if nx == ox && ny == oy {
+				conflict = true
+				break
+			}
+			// 他の敵の移動先と重複（インデックスが小さい方を優先）
+			if nx == targets[j][0] && ny == targets[j][1] && i > j {
+				conflict = true
+				break
+			}
+		}
+		if !conflict {
+			e.Move(nx, ny, grid)
+		}
 	}
 }
 

--- a/state/gamestate_test.go
+++ b/state/gamestate_test.go
@@ -265,6 +265,64 @@ func TestGameClearOnLastStage(t *testing.T) {
 	}
 }
 
+// --- 敵の重複移動防止 ---
+
+func TestEnemiesDoNotOverlapSameTarget(t *testing.T) {
+	// 2体の敵が同じセルへ移動しようとする状況
+	// グリッド: 横一列の通路、プレイヤーが右端
+	// E1(1,1) E2(2,1) → 両者とも右へ進もうとするが、E2 の移動先(3,1)に E1 も行こうとする
+	gs := newGameStateWithGrid([]string{
+		"++++++",
+		"+    +",
+		"++++++",
+	}, 3)
+	gs.Player.X = 4
+	gs.Player.Y = 1
+	gs.Enemies = []Enemy{
+		NewHunterBuilder().Build(1, 1),
+		NewHunterBuilder().Build(2, 1),
+	}
+	gs.Phase = PhasePlaying
+	gs.Stages[0].GameSpeed = time.Second / 60 // 即座に移動
+
+	_ = gs.Update(input.CmdNone, 0)
+
+	x0, y0 := gs.Enemies[0].Position()
+	x1, y1 := gs.Enemies[1].Position()
+	if x0 == x1 && y0 == y1 {
+		t.Errorf("enemies should not occupy the same cell, both at (%d,%d)", x0, y0)
+	}
+}
+
+func TestEnemiesDoNotMoveToOccupiedCell(t *testing.T) {
+	// E1 の現在地に E2 が移動しようとする場合、E2 は移動しない
+	gs := newGameStateWithGrid([]string{
+		"++++++",
+		"+    +",
+		"++++++",
+	}, 3)
+	gs.Player.X = 4
+	gs.Player.Y = 1
+	// E1(3,1) E2(1,1): E2 は右へ進もうとするが、E1 がいるので最終的に重なってはいけない
+	gs.Enemies = []Enemy{
+		NewHunterBuilder().Build(3, 1),
+		NewHunterBuilder().Build(1, 1),
+	}
+	gs.Phase = PhasePlaying
+	gs.Stages[0].GameSpeed = time.Second / 60
+
+	// 複数フレーム動かしても重複しない
+	for range 10 {
+		_ = gs.Update(input.CmdNone, 0)
+		x0, y0 := gs.Enemies[0].Position()
+		x1, y1 := gs.Enemies[1].Position()
+		if x0 == x1 && y0 == y1 {
+			t.Errorf("enemies overlapped at (%d,%d)", x0, y0)
+			return
+		}
+	}
+}
+
 // --- Stage() アクセサ ---
 
 func TestStageAccessor(t *testing.T) {


### PR DESCRIPTION
## 原因

`moveEnemies()` が各敵を独立して Think → Move していたため、
複数の敵が同一フレームで同じセルへ移動できてしまっていた。

## 修正内容

2パス方式に変更:

1. **全員の移動先を先に計算**（`Think` のみ、まだ動かさない）
2. **重複チェック後に移動**
   - 移動先に他の敵が**現在いる**場合 → スキップ
   - 複数の敵が**同一セルへ移動**しようとする場合 → インデックスが大きい方をスキップ

## テスト

- `TestEnemiesDoNotOverlapSameTarget`: 同一移動先への衝突
- `TestEnemiesDoNotMoveToOccupiedCell`: 占有セルへの侵入（10フレーム継続確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)