### PR TITLE
fix: Opening のキーをゲームに渡さない / feat: 準備画面の追加

### DIFF
--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -66,6 +66,9 @@ func (r *Renderer) Draw(screen *ebiten.Image, gs *state.GameState) {
 	case state.PhaseOpening:
 		r.drawGame(screen, gs)
 		r.drawOpeningOverlay(screen)
+	case state.PhaseReady:
+		r.drawGame(screen, gs)
+		r.drawReadyOverlay(screen, gs)
 	case state.PhasePlaying:
 		r.drawGame(screen, gs)
 	case state.PhaseGameOver:
@@ -176,6 +179,17 @@ func (r *Renderer) drawOpeningOverlay(screen *ebiten.Image) {
 	cy := ScreenHeight / 2
 	r.drawCharCentered(screen, "PacVim", cx, cy-30, colorTitle)
 	r.drawCharCentered(screen, "Learn Vim by playing Pac-Man!", cx, cy-10, colorHint)
+	r.drawCharCentered(screen, "Press any key to start", cx, cy+16, colorStatusText)
+	r.drawCharCentered(screen, "q: quit", cx, cy+36, colorHint)
+}
+
+func (r *Renderer) drawReadyOverlay(screen *ebiten.Image, gs *state.GameState) {
+	vector.FillRect(screen, 0, 0, ScreenWidth, ScreenHeight, colorOverlay, false)
+	cx := ScreenWidth / 2
+	cy := ScreenHeight / 2
+	stage := gs.Stage()
+	r.drawCharCentered(screen, fmt.Sprintf("Level %d", stage.Level), cx, cy-30, colorTitle)
+	r.drawCharCentered(screen, fmt.Sprintf("Life: %d", gs.Life), cx, cy-10, colorHint)
 	r.drawCharCentered(screen, "Press any key to start", cx, cy+16, colorStatusText)
 	r.drawCharCentered(screen, "q: quit", cx, cy+36, colorHint)
 }

--- a/state/gamestate.go
+++ b/state/gamestate.go
@@ -14,11 +14,11 @@ var ErrQuit = errors.New("quit")
 type GamePhase int
 
 const (
-	PhaseOpening   GamePhase = iota // 開幕画面（最初のキー入力待ち）
-	PhasePlaying                    // プレイ中
-	PhaseStageClear                 // ステージクリア
-	PhaseGameOver                   // ゲームオーバー
-	PhaseGameClear                  // 全ステージクリア
+	PhaseOpening GamePhase = iota // 開幕画面（最初のキー入力待ち）
+	PhaseReady                    // 準備画面（ステージ開始前・ミス後）
+	PhasePlaying                  // プレイ中
+	PhaseGameOver                 // ゲームオーバー
+	PhaseGameClear                // 全ステージクリア
 )
 
 // GameState はゲーム全体の状態を保持する。
@@ -104,19 +104,20 @@ func (gs *GameState) Update(cmd input.Command, ch rune) error {
 
 	switch gs.Phase {
 	case PhaseOpening:
-		gs.updateOpening(cmd, ch)
+		gs.updateWaitKey(cmd, PhaseReady)
+	case PhaseReady:
+		gs.updateWaitKey(cmd, PhasePlaying)
 	case PhasePlaying:
 		gs.updatePlaying(cmd, ch)
 	}
 	return nil
 }
 
-// updateOpening はオープニング画面の更新処理。
-// CmdNone 以外のコマンドが来たらゲームを開始する。
-func (gs *GameState) updateOpening(cmd input.Command, ch rune) {
+// updateWaitKey は CmdNone 以外のキー入力で next フェーズへ遷移する。
+// キーはゲームコマンドとして処理しない（消費するだけ）。
+func (gs *GameState) updateWaitKey(cmd input.Command, next GamePhase) {
 	if cmd != input.CmdNone {
-		gs.Phase = PhasePlaying
-		gs.updatePlaying(cmd, ch)
+		gs.Phase = next
 	}
 }
 
@@ -207,7 +208,7 @@ func (gs *GameState) handleStageClear() {
 	if gs.StageIdx+1 < len(gs.Stages) {
 		gs.StageIdx++
 		_ = gs.loadStage()
-		gs.Phase = PhasePlaying
+		gs.Phase = PhaseReady
 	} else {
 		gs.Phase = PhaseGameClear
 	}
@@ -220,6 +221,6 @@ func (gs *GameState) handlePlayerDeath() {
 		gs.Phase = PhaseGameOver
 	} else {
 		_ = gs.loadStage()
-		gs.Phase = PhasePlaying
+		gs.Phase = PhaseReady
 	}
 }

--- a/state/gamestate_test.go
+++ b/state/gamestate_test.go
@@ -109,8 +109,8 @@ func TestUpdateOpeningStartsOnCommand(t *testing.T) {
 		t.Fatalf("NewGameState failed: %v", err)
 	}
 	_ = gs.Update(input.CmdMoveRight, 0)
-	if gs.Phase != PhasePlaying {
-		t.Errorf("command should transition to PhasePlaying, got %v", gs.Phase)
+	if gs.Phase != PhaseReady {
+		t.Errorf("command should transition to PhaseReady, got %v", gs.Phase)
 	}
 }
 
@@ -229,8 +229,8 @@ func TestStageClearAdvancesStage(t *testing.T) {
 	if gs.StageIdx != 1 {
 		t.Errorf("want StageIdx=1 after clear, got %d", gs.StageIdx)
 	}
-	if gs.Phase != PhasePlaying {
-		t.Errorf("want PhasePlaying after stage clear, got %v", gs.Phase)
+	if gs.Phase != PhaseReady {
+		t.Errorf("want PhaseReady after stage clear, got %v", gs.Phase)
 	}
 }
 


### PR DESCRIPTION
## バグ修正

**Opening 画面でキーが二重に処理される問題**

`updateOpening` が `PhasePlaying` へ遷移した直後に同じコマンドで `updatePlaying` を呼んでいたため、スタートキー（例: `j`）がゲームコマンドとしても実行されていた。

→ `updateWaitKey` に統一し、キーは「フェーズ遷移のみ」に使用してゲームには渡さないよう修正。

## 機能追加

**準備画面（`PhaseReady`）の追加**

| タイミング | 変更前 | 変更後 |
|---|---|---|
| ゲーム起動 | Opening → Playing | Opening → **Ready** → Playing |
| ステージクリア | 即 Playing へ | **Ready** → Playing |
| ミス（残機あり） | 即 Playing へ | **Ready** → Playing |

準備画面では Level・残機・「Press any key to start」を表示。

🤖 Generated with [Claude Code](https://claude.com/claude-code)