### PR TITLE
fix: キーリピートの実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -337,6 +337,37 @@ func gridToScreen(gx, gy int) (float64, float64) {
 
 ---
 
+## 入力実装の注意事項（`input/input.go`）
+
+### `IsKeyJustPressed` と `IsKeyPressed` の使い分け
+
+Ebitengine の入力 API には2種類あります。
+
+| API | 挙動 | 用途 |
+|---|---|---|
+| `inpututil.IsKeyJustPressed(key)` | 押した瞬間の1フレームのみ true | 1回だけ発火させたいコマンド |
+| `ebiten.IsKeyPressed(key)` | 押している間ずっと true | リピート処理の継続判定 |
+
+移動キーに `IsKeyJustPressed` のみを使うと、押し続けても最初の1回しか反応しません。
+**移動キーは必ずリピート処理を経由して発火させてください。**
+
+### キーリピートの実装
+
+`Handler` にリピート状態（`repeatKey`・`repeatFrames`）を持たせ、以下の挙動を実現しています。
+
+- 押した瞬間 → 即座に発火（`IsKeyJustPressed` で検出）
+- 押し続けて `repeatInitialDelay` フレーム（約300ms）経過後 → `repeatInterval` フレーム（約60ms）ごとに繰り返し発火
+- キーを離したら → `repeatKey` と `repeatFrames` をリセット
+
+### リピート対象のキー
+
+| 区分 | キー | 理由 |
+|---|---|---|
+| **対象（連続発火）** | `h` `j` `k` `l` `w` `e` `b` | 押し続けでカーソルを連続移動させたい |
+| **対象外（1回のみ）** | `g`（gg の1打目）、`q`、`f/F/t/T`（文字待ち）、数字キー | 誤操作を防ぐ・2ストロークの状態管理を壊さない |
+
+---
+
 ## ステージの定義（`state/stage.go`）
 
 ```go

--- a/docs/decisions/2026-03-30-ebitengine.md
+++ b/docs/decisions/2026-03-30-ebitengine.md
@@ -1,0 +1,40 @@
+# Ebitengineのキーリピート実装方針
+
+- Date: 2026-03-30
+- Type: ADR
+- Status: Active
+- Author: masahiro.kasatani
+
+## Context
+
+旧 termbox 版では `termbox.PollEvent()` がブロッキング呼び出しであり、OS レベルのキーリピートがそのままイベントとして流れてきていた。
+Ebitengine へ移行後は TPS=60 の固定ループ内でポーリングする方式に変わり、`inpututil.IsKeyJustPressed` は押した瞬間の1フレームのみ true を返す。
+そのため移動キー（h j k l w e b）を押し続けても最初の1回しか反応しないという問題が発生した。
+
+## Decision
+
+`input.Handler` にリピート状態（`repeatKey ebiten.Key`、`repeatFrames int`）を持たせ、ソフトウェアでキーリピートを実装する。
+- 押した瞬間は `inpututil.IsKeyJustPressed` で即座に発火する。
+- 押し続けて `repeatInitialDelay`（18フレーム ≈ 300ms）経過後、`repeatInterval`（4フレーム ≈ 60ms）ごとに繰り返し発火する。
+- リピート対象は移動系コマンド（h j k l w e b）のみとし、g・q・f/t 系・数字キーは対象外とする。
+
+## Consequences
+
+**メリット**
+- キーを押し続けると自然に連続移動でき、ゲームの操作感が向上する。
+- リピートのタイミング（初期遅延・間隔）を定数で調整しやすい。
+- `state` パッケージへの影響がなく、`input.Handler` 内で完結する。
+
+**トレードオフ**
+- リピートのタイミング定数はゲームの TPS（60）に依存する。TPS を変更する場合は定数の見直しが必要。
+- OS のキーリピート設定と独立しているため、ユーザーの OS 設定とは異なるリピート速度になる。
+
+## Alternatives Considered
+
+- **OS のキーリピートをそのまま使う**: Ebitengine のポーリング方式では OS リピートイベントを直接取得できないため採用不可。
+- **`ebiten.IsKeyPressed` のみを使う**: 押している間ずっと true になるため毎フレーム発火してしまい、カーソルが速すぎる。初期遅延を設けるリピート処理が必要。
+
+## Related Files
+
+- `CLAUDE.md`
+- `input/input.go`

--- a/input/input.go
+++ b/input/input.go
@@ -40,13 +40,22 @@ const (
 	CmdQuit                 // q
 )
 
+// キーリピートのタイミング定数（TPS=60 基準）
+const (
+	repeatInitialDelay = 18 // 最初のリピートまでのフレーム数（約300ms）
+	repeatInterval     = 4  // リピート間隔のフレーム数（約60ms）
+)
+
 // Handler はキー入力を毎フレーム読み取り Command に変換する。
 // 2ストロークコマンド（gg, ge, f/t）の状態はここで管理する。
+// 移動キーのリピート状態もここで管理する。
 type Handler struct {
-	prevG      bool    // g を受け取った後、次のキーを待つ
-	awaitChar  bool    // f/F/t/T の後、対象文字を待つ
-	pendingCmd Command // awaitChar 中の保留コマンド
-	inNumMode  bool    // 数字蓄積中かどうか（0 の振り分けに使用）
+	prevG        bool       // g を受け取った後、次のキーを待つ
+	awaitChar    bool       // f/F/t/T の後、対象文字を待つ
+	pendingCmd   Command    // awaitChar 中の保留コマンド
+	inNumMode    bool       // 数字蓄積中かどうか（0 の振り分けに使用）
+	repeatKey    ebiten.Key // 現在リピート中のキー
+	repeatFrames int        // repeatKey を押し続けたフレーム数
 }
 
 // Read は1フレーム分のキー入力を読み取り、(Command, rune) を返す。
@@ -134,21 +143,43 @@ func (h *Handler) Read() (Command, rune) {
 			return CmdBlockForward, 0
 		}
 	} else {
+		// 移動キーはリピート処理を経由して発火する
+		repeatableKeys := []struct {
+			key ebiten.Key
+			cmd Command
+		}{
+			{ebiten.KeyH, CmdMoveLeft},
+			{ebiten.KeyJ, CmdMoveDown},
+			{ebiten.KeyK, CmdMoveUp},
+			{ebiten.KeyL, CmdMoveRight},
+			{ebiten.KeyW, CmdWordForward},
+			{ebiten.KeyE, CmdWordEnd},
+			{ebiten.KeyB, CmdWordBack},
+		}
+		for _, rk := range repeatableKeys {
+			if ebiten.IsKeyPressed(rk.key) {
+				if inpututil.IsKeyJustPressed(rk.key) {
+					h.repeatKey = rk.key
+					h.repeatFrames = 0
+					h.inNumMode = false
+					return rk.cmd, 0
+				}
+				if h.repeatKey == rk.key {
+					h.repeatFrames++
+					elapsed := h.repeatFrames - repeatInitialDelay
+					if elapsed >= 0 && elapsed%repeatInterval == 0 {
+						h.inNumMode = false
+						return rk.cmd, 0
+					}
+				}
+				return CmdNone, 0
+			}
+		}
+		// リピート中のキーが離されたらリセット
+		h.repeatKey = 0
+		h.repeatFrames = 0
+
 		switch {
-		case inpututil.IsKeyJustPressed(ebiten.KeyH):
-			return CmdMoveLeft, 0
-		case inpututil.IsKeyJustPressed(ebiten.KeyJ):
-			return CmdMoveDown, 0
-		case inpututil.IsKeyJustPressed(ebiten.KeyK):
-			return CmdMoveUp, 0
-		case inpututil.IsKeyJustPressed(ebiten.KeyL):
-			return CmdMoveRight, 0
-		case inpututil.IsKeyJustPressed(ebiten.KeyW):
-			return CmdWordForward, 0
-		case inpututil.IsKeyJustPressed(ebiten.KeyE):
-			return CmdWordEnd, 0
-		case inpututil.IsKeyJustPressed(ebiten.KeyB):
-			return CmdWordBack, 0
 		case inpututil.IsKeyJustPressed(ebiten.KeyG):
 			h.prevG = true
 			return CmdNone, 0


### PR DESCRIPTION
## Summary

- `h` `j` `k` `l` `w` `e` `b` を押し続けても1回しか移動しない問題を修正
- `input.Handler` にリピート状態（`repeatKey`・`repeatFrames`）を追加し、ソフトウェアキーリピートを実装
- 初期遅延 18フレーム（約300ms）、リピート間隔 4フレーム（約60ms）

## 変更内容

- `input/input.go`: 移動キーのリピート処理を実装。`IsKeyJustPressed` のみで判定していた h/j/k/l/w/e/b を、`ebiten.IsKeyPressed` を使ったリピートロジックに変更
- `CLAUDE.md`: 「入力実装の注意事項」セクションを追加（`IsKeyJustPressed` vs `IsKeyPressed` の使い分け・リピート対象キーの区別）
- `docs/decisions/2026-03-30-ebitengine.md`: ADR を作成（termbox との違い・今回の解決アプローチを記録）

## Test plan

- [ ] `go build ./...` が通ること
- [ ] `make run` でゲームを起動し、`j` を押し続けると連続で下移動すること
- [ ] `h` `k` `l` `w` `e` `b` でも同様に連続移動すること
- [ ] `g` `q` `f` `t` 系・数字キーはリピートしないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)