### PR TITLE
feat: 死亡演出フェーズ（PhaseDead）の追加

### DIFF
--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -71,6 +71,9 @@ func (r *Renderer) Draw(screen *ebiten.Image, gs *state.GameState) {
 		r.drawReadyOverlay(screen, gs)
 	case state.PhasePlaying:
 		r.drawGame(screen, gs)
+	case state.PhaseDead:
+		r.drawGame(screen, gs)
+		r.drawDeadOverlay(screen)
 	case state.PhaseGameOver:
 		r.drawGame(screen, gs)
 		r.drawMessageOverlay(screen, "GAME OVER", "press any key to quit")
@@ -192,6 +195,13 @@ func (r *Renderer) drawReadyOverlay(screen *ebiten.Image, gs *state.GameState) {
 	r.drawCharCentered(screen, fmt.Sprintf("Life: %d", gs.Life), cx, cy-10, colorHint)
 	r.drawCharCentered(screen, "Press any key to start", cx, cy+16, colorStatusText)
 	r.drawCharCentered(screen, "q: quit", cx, cy+36, colorHint)
+}
+
+func (r *Renderer) drawDeadOverlay(screen *ebiten.Image) {
+	vector.FillRect(screen, 0, 0, ScreenWidth, ScreenHeight, color.RGBA{120, 0, 0, 80}, false)
+	cx := ScreenWidth / 2
+	cy := ScreenHeight / 2
+	r.drawCharCentered(screen, "MISS...", cx, cy, colorTitle)
 }
 
 func (r *Renderer) drawMessageOverlay(screen *ebiten.Image, title, hint string) {

--- a/state/gamestate.go
+++ b/state/gamestate.go
@@ -14,12 +14,16 @@ var ErrQuit = errors.New("quit")
 type GamePhase int
 
 const (
-	PhaseOpening GamePhase = iota // 開幕画面（最初のキー入力待ち）
-	PhaseReady                    // 準備画面（ステージ開始前・ミス後）
-	PhasePlaying                  // プレイ中
-	PhaseGameOver                 // ゲームオーバー
-	PhaseGameClear                // 全ステージクリア
+	PhaseOpening  GamePhase = iota // 開幕画面（最初のキー入力待ち）
+	PhaseReady                     // 準備画面（ステージ開始前・ミス後）
+	PhasePlaying                   // プレイ中
+	PhaseDead                      // 死亡演出中（deadDuration フレーム後に PhaseReady へ遷移）
+	PhaseGameOver                  // ゲームオーバー
+	PhaseGameClear                 // 全ステージクリア
 )
+
+// deadDuration は PhaseDead の持続フレーム数（約1.5秒 @ TPS=60）。
+const deadDuration = 90
 
 // GameState はゲーム全体の状態を保持する。
 type GameState struct {
@@ -30,6 +34,7 @@ type GameState struct {
 	Life      int
 	EnemyTick int
 	Phase     GamePhase
+	deadTimer int // PhaseDead の経過フレーム数
 }
 
 // NewGameState は初期状態の GameState を生成する。
@@ -109,8 +114,19 @@ func (gs *GameState) Update(cmd input.Command, ch rune) error {
 		gs.updateWaitKey(cmd, PhasePlaying)
 	case PhasePlaying:
 		gs.updatePlaying(cmd, ch)
+	case PhaseDead:
+		gs.updateDead()
 	}
 	return nil
+}
+
+// updateDead は PhaseDead のフレームを進め、deadDuration 経過後に PhaseReady へ遷移する。
+func (gs *GameState) updateDead() {
+	gs.deadTimer++
+	if gs.deadTimer >= deadDuration {
+		_ = gs.loadStage()
+		gs.Phase = PhaseReady
+	}
 }
 
 // updateWaitKey は CmdNone 以外のキー入力で next フェーズへ遷移する。
@@ -215,12 +231,13 @@ func (gs *GameState) handleStageClear() {
 }
 
 // handlePlayerDeath はプレイヤー死亡時の処理を行う。
+// ライフが残っている場合は PhaseDead へ遷移し、loadStage は deadDuration 後まで遅らせる。
 func (gs *GameState) handlePlayerDeath() {
 	gs.Life--
 	if gs.Life <= 0 {
 		gs.Phase = PhaseGameOver
 	} else {
-		_ = gs.loadStage()
-		gs.Phase = PhaseReady
+		gs.deadTimer = 0
+		gs.Phase = PhaseDead
 	}
 }

--- a/state/gamestate_test.go
+++ b/state/gamestate_test.go
@@ -211,6 +211,60 @@ func TestPoisonKillsPlayer(t *testing.T) {
 	}
 }
 
+// --- PhaseDead ---
+
+func TestPlayerDeathTransitionsToPhaseDead(t *testing.T) {
+	gs := newGameStateWithGrid([]string{
+		"+++++",
+		"+   +",
+		"+++++",
+	}, 3)
+	gs.Enemies = []Enemy{NewHunterBuilder().Build(gs.Player.X, gs.Player.Y)}
+	gs.Phase = PhasePlaying
+
+	_ = gs.Update(input.CmdNone, 0)
+	if gs.Phase != PhaseDead {
+		t.Errorf("want PhaseDead after death, got %v", gs.Phase)
+	}
+}
+
+func TestPhaseDeadTransitionsToPhaseReadyAfterDuration(t *testing.T) {
+	gs := newGameStateWithGrid([]string{
+		"+++++",
+		"+   +",
+		"+++++",
+	}, 3)
+	gs.Phase = PhaseDead
+	gs.deadTimer = 0
+
+	for i := 0; i < deadDuration-1; i++ {
+		_ = gs.Update(input.CmdNone, 0)
+		if gs.Phase != PhaseDead {
+			t.Fatalf("want PhaseDead at frame %d, got %v", i, gs.Phase)
+		}
+	}
+	_ = gs.Update(input.CmdNone, 0)
+	if gs.Phase != PhaseReady {
+		t.Errorf("want PhaseReady after deadDuration, got %v", gs.Phase)
+	}
+}
+
+func TestPhaseDeadIgnoresPlayerInput(t *testing.T) {
+	gs := newGameStateWithGrid([]string{
+		"+++++",
+		"+   +",
+		"+++++",
+	}, 3)
+	gs.Phase = PhaseDead
+	gs.deadTimer = 0
+	startX := gs.Player.X
+
+	_ = gs.Update(input.CmdMoveRight, 0)
+	if gs.Player.X != startX {
+		t.Errorf("player should not move during PhaseDead, got X=%d", gs.Player.X)
+	}
+}
+
 // --- ステージクリア ---
 
 func TestStageClearAdvancesStage(t *testing.T) {


### PR DESCRIPTION
## Summary

- 死亡直後に即 `PhaseReady` へ遷移せず、約1.5秒間 `PhaseDead` で停止するようにした
- 死亡時のフィールド（敵の位置・毒など）がそのまま表示されるため、やられた原因が分かりやすくなる
- `PhaseDead` 中は赤いオーバーレイと "MISS..." メッセージを表示

## 変更内容

| ファイル | 変更 |
|---|---|
| `state/gamestate.go` | `PhaseDead` フェーズ・`deadDuration`(90f) 定数・`deadTimer` フィールドを追加。`handlePlayerDeath` で `PhaseDead` へ遷移、`updateDead` で時間経過後に `loadStage + PhaseReady` |
| `renderer/renderer.go` | `PhaseDead` 時にフィールド描画＋赤オーバーレイ＋"MISS..." を表示する `drawDeadOverlay` を追加 |
| `state/gamestate_test.go` | `PhaseDead` への遷移・持続フレーム数・入力無視の3テストを追加 |

## フェーズ遷移

```
PhasePlaying → PhaseDead（90フレーム ≈ 1.5秒）→ PhaseReady
                                                 ↓ ライフ0
                                             PhaseGameOver
```

## Test plan

- [ ] `go test ./state/...` が通ること
- [ ] `make run` でゲームを起動し、敵に捕まった際に約1.5秒間フィールドが表示されること
- [ ] 毒を踏んだ際も同様に表示されること
- [ ] その後 PhaseReady（準備画面）に遷移すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)