### PR TITLE
feat: f/F/t/T/;/, コマンドの実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -642,7 +642,7 @@ make wasm         # WebAssembly ビルド（docs/wasm/ に出力）
 
 ### Phase 3：機能拡張
 
-- [ ] `f F t T ; ,` コマンド
+- [x] `f F t T ; ,` コマンド
 - [ ] ステージごとの使用可能コマンド制限
 - [ ] スプライト画像・SE
 - [ ] WebAssembly 配布

--- a/state/player.go
+++ b/state/player.go
@@ -11,14 +11,22 @@ const (
 	PlayerWon
 )
 
+// findCmd は f/F/t/T コマンドの繰り返し（;/,）に必要な情報を保持する。
+type findCmd struct {
+	isTill  bool // true = t/T、false = f/F
+	forward bool // true = 右方向、false = 左方向
+	ch      rune // 検索対象文字
+}
+
 // Player はプレイヤーの状態と Vim コマンドのロジックを保持する。
 type Player struct {
 	X, Y        int
 	Score       int
 	TargetScore int
 	State       PlayerState
-	inputNum    int  // カウント蓄積（3w の "3" など）
-	inputG      bool // g 入力待ち（gg コマンド用、input.Handler で管理するため通常は未使用）
+	inputNum    int      // カウント蓄積（3w の "3" など）
+	inputG      bool     // g 入力待ち（gg コマンド用、input.Handler で管理するため通常は未使用）
+	lastFind    *findCmd // f/t の繰り返し用（; , コマンド）
 }
 
 // Apply はコマンドをプレイヤー状態に適用する。
@@ -77,6 +85,26 @@ func (p *Player) Apply(cmd input.Command, ch rune, stage *Stage, enemies []Enemy
 			p.gotoLine(p.inputNum, stage, enemies)
 		} else {
 			p.gotoLastLine(stage, enemies)
+		}
+
+	case input.CmdFindForward:
+		p.applyFind(ch, true, false, stage, enemies)
+	case input.CmdFindBack:
+		p.applyFind(ch, false, false, stage, enemies)
+	case input.CmdTillForward:
+		p.applyFind(ch, true, true, stage, enemies)
+	case input.CmdTillBack:
+		p.applyFind(ch, false, true, stage, enemies)
+
+	case input.CmdRepeatFind:
+		if p.lastFind != nil {
+			f := p.lastFind
+			p.applyFind(f.ch, f.forward, f.isTill, stage, enemies)
+		}
+	case input.CmdRepeatFindRev:
+		if p.lastFind != nil {
+			f := p.lastFind
+			p.applyFind(f.ch, !f.forward, f.isTill, stage, enemies)
 		}
 	}
 
@@ -298,6 +326,61 @@ func (p *Player) gotoLastLine(stage *Stage, enemies []Enemy) {
 			return
 		}
 	}
+}
+
+// charMatchesCell は入力文字がセルの種別と対応するかを返す。
+// f/t コマンドで検索する文字→セル種別の対応を定義する。
+func charMatchesCell(ch rune, cell Cell) bool {
+	switch ch {
+	case charApple: // 'o'
+		return cell.Kind == CellApple
+	case charPoison: // 'X'
+		return cell.Kind == CellPoison
+	case ' ':
+		return cell.Kind == CellSpace || cell.Kind == CellAppleEaten
+	}
+	return false
+}
+
+// applyFind は f/F/t/T の検索・移動ロジックを実行する。
+// forward=true で右方向、isTill=true で1マス手前止まり（t/T 挙動）。
+func (p *Player) applyFind(ch rune, forward bool, isTill bool, stage *Stage, enemies []Enemy) {
+	dx := 1
+	if !forward {
+		dx = -1
+	}
+
+	// 現在行で対象文字を検索
+	targetX := -1
+	for x := p.X + dx; x >= 0 && x < stage.Grid.Width; x += dx {
+		if charMatchesCell(ch, stage.Grid.At(x, p.Y)) {
+			targetX = x
+			break
+		}
+	}
+	if targetX == -1 {
+		return
+	}
+
+	// t/T は1マス手前で止まる
+	if isTill {
+		targetX -= dx
+		if targetX == p.X {
+			return
+		}
+	}
+
+	// walk で1ステップずつ移動
+	for p.X != targetX {
+		if !p.walkTo(p.X+dx, p.Y, stage, enemies) {
+			break
+		}
+		if p.State != PlayerAlive {
+			return
+		}
+	}
+
+	p.lastFind = &findCmd{isTill: isTill, forward: forward, ch: ch}
 }
 
 // gotoLine は n 行目（1-indexed）の最初のワードへジャンプする（Ngg / NG）。

--- a/state/player_test.go
+++ b/state/player_test.go
@@ -540,6 +540,193 @@ func TestCountNotResetByCmdNone(t *testing.T) {
 	}
 }
 
+// --- f F t T ; ,（文字検索） ---
+
+// TestFindForward: fo で右方向の次の o（リンゴ）まで walk 移動し、リンゴを取得する。
+// "+  o o  +" → x=3 に最初の o がある
+func TestFindForward(t *testing.T) {
+	stage := newStage([]string{
+		"++++++++++",
+		"+  o o   +",
+		"++++++++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive, TargetScore: 99}
+	p.Apply(input.CmdFindForward, 'o', stage, nil)
+	// 最初の o は x=3
+	if p.X != 3 {
+		t.Errorf("fo: want X=3, got X=%d", p.X)
+	}
+	// x=3 の o を取得
+	if p.Score != 1 {
+		t.Errorf("fo: want Score=1, got %d", p.Score)
+	}
+}
+
+// TestFindForwardCollectsApplesAlongPath: fo で経路上のリンゴも収集する。
+func TestFindForwardCollectsApplesAlongPath(t *testing.T) {
+	stage := newStage([]string{
+		"+++++++",
+		"+ oo o+",
+		"+++++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive, TargetScore: 99}
+	// fo: 最初の o は x=2。経路上のリンゴ（x=2）を取得
+	p.Apply(input.CmdFindForward, 'o', stage, nil)
+	if p.X != 2 {
+		t.Errorf("fo: want X=2, got X=%d", p.X)
+	}
+	// 2回目の fo: 次の o は x=3。x=3 のリンゴを取得
+	p.Apply(input.CmdFindForward, 'o', stage, nil)
+	if p.X != 3 {
+		t.Errorf("fo: want X=3, got X=%d", p.X)
+	}
+	if p.Score != 2 {
+		t.Errorf("fo: want Score=2, got %d", p.Score)
+	}
+}
+
+// TestFindBack: Fo で左方向の次の o まで移動する。
+// "+  o o  +" → x=5 に右側の o がある
+func TestFindBack(t *testing.T) {
+	stage := newStage([]string{
+		"++++++++++",
+		"+  o o   +",
+		"++++++++++",
+	})
+	p := &Player{X: 8, Y: 1, State: PlayerAlive, TargetScore: 99}
+	p.Apply(input.CmdFindBack, 'o', stage, nil)
+	// 右から見て最初の o は x=5
+	if p.X != 5 {
+		t.Errorf("Fo: want X=5, got X=%d", p.X)
+	}
+}
+
+// TestTillForward: to で右方向の次の o の1つ手前まで移動する。
+func TestTillForward(t *testing.T) {
+	stage := newStage([]string{
+		"+++++++",
+		"+   o +",
+		"+++++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive, TargetScore: 99}
+	p.Apply(input.CmdTillForward, 'o', stage, nil)
+	// o は x=4、1つ手前は x=3
+	if p.X != 3 {
+		t.Errorf("to: want X=3, got X=%d", p.X)
+	}
+}
+
+// TestTillBack: To で左方向の次の o の1つ右まで移動する。
+func TestTillBack(t *testing.T) {
+	stage := newStage([]string{
+		"+++++++",
+		"+ o   +",
+		"+++++++",
+	})
+	p := &Player{X: 5, Y: 1, State: PlayerAlive, TargetScore: 99}
+	p.Apply(input.CmdTillBack, 'o', stage, nil)
+	// o は x=2、1つ右は x=3
+	if p.X != 3 {
+		t.Errorf("To: want X=3, got X=%d", p.X)
+	}
+}
+
+// TestFindNotFound: 対象文字が存在しない場合は移動しない。
+func TestFindNotFound(t *testing.T) {
+	stage := newStage([]string{
+		"+++++",
+		"+   +",
+		"+++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive}
+	p.Apply(input.CmdFindForward, 'o', stage, nil)
+	if p.X != 1 {
+		t.Errorf("fo (not found): should not move, got X=%d", p.X)
+	}
+}
+
+// TestRepeatFind: fo の後に ; で同じ方向に繰り返し移動する。
+// "+  o   o   o  +" → x=3, x=7, x=11 に o がある
+func TestRepeatFind(t *testing.T) {
+	stage := newStage([]string{
+		"+++++++++++++++",
+		"+  o   o   o  +",
+		"+++++++++++++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive, TargetScore: 99}
+	// fo: x=3 へ
+	p.Apply(input.CmdFindForward, 'o', stage, nil)
+	if p.X != 3 {
+		t.Fatalf("fo: want X=3, got X=%d", p.X)
+	}
+	// ; で繰り返し: x=7 へ
+	p.Apply(input.CmdRepeatFind, 0, stage, nil)
+	if p.X != 7 {
+		t.Errorf(";: want X=7, got X=%d", p.X)
+	}
+	// ; で繰り返し: x=11 へ
+	p.Apply(input.CmdRepeatFind, 0, stage, nil)
+	if p.X != 11 {
+		t.Errorf(";: want X=11, got X=%d", p.X)
+	}
+}
+
+// TestRepeatFindReverse: fo の後に , で逆方向に移動する。
+// プレイヤーを中間点（x=5）に置き、右の o（x=8）へ fo で移動後、
+// 左の o（x=2）へ , で戻る。fo で x=2 は通らないので食べられていない。
+func TestRepeatFindReverse(t *testing.T) {
+	stage := newStage([]string{
+		"+++++++++++",
+		"+ o     o +",
+		"+++++++++++",
+	})
+	// x=2: o, x=8: o。プレイヤーは x=5 からスタート
+	p := &Player{X: 5, Y: 1, State: PlayerAlive, TargetScore: 99}
+	// fo: x=8 へ（x=2 は通らないので食べられない）
+	p.Apply(input.CmdFindForward, 'o', stage, nil)
+	if p.X != 8 {
+		t.Fatalf("fo: want X=8, got X=%d", p.X)
+	}
+	// lastFind = {forward: true, ch: 'o'}
+	// , で逆方向（左）: x=7 から検索 → x=2 の o へ
+	p.Apply(input.CmdRepeatFindRev, 0, stage, nil)
+	if p.X != 2 {
+		t.Errorf(",: want X=2, got X=%d", p.X)
+	}
+}
+
+// TestRepeatFindNilLastFind: lastFind が nil の場合は何もしない。
+func TestRepeatFindNilLastFind(t *testing.T) {
+	stage := newStage([]string{
+		"+++++++",
+		"+ o o +",
+		"+++++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive}
+	p.Apply(input.CmdRepeatFind, 0, stage, nil)
+	if p.X != 1 {
+		t.Errorf("; with no lastFind: should not move, got X=%d", p.X)
+	}
+}
+
+// TestFindWalkDiesOnPoison: fo は walk なので経路上に毒があれば死亡する。
+func TestFindWalkDiesOnPoison(t *testing.T) {
+	stage := newStage([]string{
+		"+++++++",
+		"+ X o +",
+		"+++++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive, TargetScore: 99}
+	p.Apply(input.CmdFindForward, 'o', stage, nil)
+	// 経路上の x=2 に毒があるので死亡
+	if p.State != PlayerDead {
+		t.Errorf("fo through poison: want PlayerDead, got %v", p.State)
+	}
+	if p.X != 2 {
+		t.Errorf("fo through poison: want stopped at X=2, got X=%d", p.X)
+	}
+}
+
 // TestCountResetAfterCommand: コマンド実行後にカウントがリセットされ、次のコマンドに引き継がれない。
 func TestCountResetAfterCommand(t *testing.T) {
 	stage := newStage([]string{


### PR DESCRIPTION
## Summary

- `state/player.go` に `f` `F` `t` `T` `;` `,` コマンドを実装
- `findCmd` struct を追加し、`;` / `,` の繰り返しに必要な情報（方向・文字・f か t か）を `lastFind` フィールドで保持
- セル種別と検索文字の対応は `charMatchesCell` で管理（`o`→CellApple、`X`→CellPoison）
- CLAUDE.md のロードマップを更新（`f F t T ; ,` にチェック）

## `go test ./state/... -v`

```
=== RUN   TestFindForward
--- PASS: TestFindForward (0.00s)
=== RUN   TestFindForwardCollectsApplesAlongPath
--- PASS: TestFindForwardCollectsApplesAlongPath (0.00s)
=== RUN   TestFindBack
--- PASS: TestFindBack (0.00s)
=== RUN   TestTillForward
--- PASS: TestTillForward (0.00s)
=== RUN   TestTillBack
--- PASS: TestTillBack (0.00s)
=== RUN   TestFindNotFound
--- PASS: TestFindNotFound (0.00s)
=== RUN   TestRepeatFind
--- PASS: TestRepeatFind (0.00s)
=== RUN   TestRepeatFindReverse
--- PASS: TestRepeatFindReverse (0.00s)
=== RUN   TestRepeatFindNilLastFind
--- PASS: TestRepeatFindNilLastFind (0.00s)
=== RUN   TestFindWalkDiesOnPoison
--- PASS: TestFindWalkDiesOnPoison (0.00s)
ok  	github.com/masahiro-kasatani/pacvim/state	(全 94 テスト PASS)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)