### PR TITLE
feat: ステージごとの使用可能コマンド制限

### DIFF
--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -71,6 +71,9 @@ func (r *Renderer) Draw(screen *ebiten.Image, gs *state.GameState) {
 		r.drawReadyOverlay(screen, gs)
 	case state.PhasePlaying:
 		r.drawGame(screen, gs)
+		if gs.RestrictedInput {
+			r.drawRestrictedMessage(screen)
+		}
 	case state.PhaseDead:
 		r.drawGame(screen, gs)
 		r.drawDeadOverlay(screen)
@@ -214,6 +217,12 @@ func (r *Renderer) drawReadyOverlay(screen *ebiten.Image, gs *state.GameState) {
 	r.drawCharCentered(screen, "Press any key to start", cx, y, colorStatusText)
 	y += lineH
 	r.drawCharCentered(screen, "q: quit", cx, y, colorHint)
+}
+
+func (r *Renderer) drawRestrictedMessage(screen *ebiten.Image) {
+	cx := ScreenWidth / 2
+	cy := ScreenHeight/2 - 30
+	r.drawCharCentered(screen, "That command is not available in this stage.", cx, cy, colorTitle)
 }
 
 func (r *Renderer) drawDeadOverlay(screen *ebiten.Image) {

--- a/state/gamestate.go
+++ b/state/gamestate.go
@@ -27,14 +27,15 @@ const deadDuration = 90
 
 // GameState はゲーム全体の状態を保持する。
 type GameState struct {
-	Stages    []Stage
-	StageIdx  int
-	Player    *Player
-	Enemies   []Enemy
-	Life      int
-	EnemyTick int
-	Phase     GamePhase
-	deadTimer int // PhaseDead の経過フレーム数
+	Stages         []Stage
+	StageIdx       int
+	Player         *Player
+	Enemies        []Enemy
+	Life           int
+	EnemyTick      int
+	Phase          GamePhase
+	deadTimer      int  // PhaseDead の経過フレーム数
+	RestrictedInput bool // 直前のフレームで封印コマンドが入力されたか
 }
 
 // NewGameState は初期状態の GameState を生成する。
@@ -137,8 +138,23 @@ func (gs *GameState) updateWaitKey(cmd input.Command, next GamePhase) {
 	}
 }
 
+// isRestricted は cmd が現在ステージの封印コマンドに含まれているか返す。
+func (gs *GameState) isRestricted(cmd input.Command) bool {
+	for _, c := range gs.Stage().RestrictedCmds {
+		if c == cmd {
+			return true
+		}
+	}
+	return false
+}
+
 // updatePlaying はプレイ中の更新処理。
 func (gs *GameState) updatePlaying(cmd input.Command, ch rune) {
+	gs.RestrictedInput = false
+	if cmd != input.CmdNone && gs.isRestricted(cmd) {
+		gs.RestrictedInput = true
+		return
+	}
 	gs.Player.Apply(cmd, ch, gs.Stage(), gs.Enemies)
 
 	gs.checkEnemyCapture()

--- a/state/gamestate_test.go
+++ b/state/gamestate_test.go
@@ -389,6 +389,116 @@ func TestStageAccessor(t *testing.T) {
 	}
 }
 
+// --- RestrictedCmds（封印コマンド） ---
+
+// newGameStateAtStage はステージ idx のグリッドを差し替えた GameState を返す。
+func newGameStateAtStage(idx int, rows []string, life int) *GameState {
+	grid := buildGrid(rows)
+	apples := countApples(grid)
+	player := &Player{
+		X:           1,
+		Y:           1,
+		State:       PlayerAlive,
+		TargetScore: apples,
+	}
+	stages := InitStages()
+	stages[idx].Grid = grid
+	return &GameState{
+		Stages:   stages,
+		StageIdx: idx,
+		Player:   player,
+		Enemies:  []Enemy{},
+		Life:     life,
+		Phase:    PhasePlaying,
+	}
+}
+
+// TestRestrictedCmdBlockedOnStage2: 2面で CmdMoveLeft を入力しても移動しない。
+func TestRestrictedCmdBlockedOnStage2(t *testing.T) {
+	gs := newGameStateAtStage(1, []string{
+		"+++++",
+		"+   +",
+		"+++++",
+	}, 3)
+	gs.Player.X = 3
+	_ = gs.Update(input.CmdMoveLeft, 0)
+	if gs.Player.X != 3 {
+		t.Errorf("stage2: CmdMoveLeft should be restricted, want X=3, got X=%d", gs.Player.X)
+	}
+}
+
+// TestRestrictedCmdAllowedOnStage2: 2面で CmdWordForward は封印されていないので移動する。
+func TestRestrictedCmdAllowedOnStage2(t *testing.T) {
+	gs := newGameStateAtStage(1, []string{
+		"++++++++",
+		"+ o  o +",
+		"++++++++",
+	}, 3)
+	gs.Player.X = 1
+	_ = gs.Update(input.CmdWordForward, 0)
+	// w で次のワード先頭（最初の o）へ移動する
+	if gs.Player.X == 1 {
+		t.Errorf("stage2: CmdWordForward should not be restricted, player should have moved")
+	}
+}
+
+// TestRestrictedCmdNotBlockedOnStage3: 3面では CmdMoveLeft は封印されていないので移動する。
+func TestRestrictedCmdNotBlockedOnStage3(t *testing.T) {
+	gs := newGameStateAtStage(2, []string{
+		"+++++",
+		"+   +",
+		"+++++",
+	}, 3)
+	gs.Player.X = 3
+	_ = gs.Update(input.CmdMoveLeft, 0)
+	if gs.Player.X != 2 {
+		t.Errorf("stage3: CmdMoveLeft should not be restricted, want X=2, got X=%d", gs.Player.X)
+	}
+}
+
+// TestRestrictedCmdNotBlockedOnStage1: 1面では CmdMoveLeft は封印されていないので移動する。
+func TestRestrictedCmdNotBlockedOnStage1(t *testing.T) {
+	gs := newGameStateAtStage(0, []string{
+		"+++++",
+		"+   +",
+		"+++++",
+	}, 3)
+	gs.Player.X = 3
+	_ = gs.Update(input.CmdMoveLeft, 0)
+	if gs.Player.X != 2 {
+		t.Errorf("stage1: CmdMoveLeft should not be restricted, want X=2, got X=%d", gs.Player.X)
+	}
+}
+
+// TestRestrictedInputFlagSet: 封印コマンドを入力したとき RestrictedInput が true になる。
+func TestRestrictedInputFlagSet(t *testing.T) {
+	gs := newGameStateAtStage(1, []string{
+		"+++++",
+		"+   +",
+		"+++++",
+	}, 3)
+	gs.Player.X = 3
+	_ = gs.Update(input.CmdMoveLeft, 0) // 2面では封印
+	if !gs.RestrictedInput {
+		t.Error("want RestrictedInput=true after restricted cmd, got false")
+	}
+}
+
+// TestRestrictedInputFlagClearedNextFrame: 次のフレームで RestrictedInput がリセットされる。
+func TestRestrictedInputFlagClearedNextFrame(t *testing.T) {
+	gs := newGameStateAtStage(1, []string{
+		"+++++",
+		"+   +",
+		"+++++",
+	}, 3)
+	gs.Player.X = 3
+	_ = gs.Update(input.CmdMoveLeft, 0) // 封印コマンド → true
+	_ = gs.Update(input.CmdNone, 0)     // 次フレーム → false
+	if gs.RestrictedInput {
+		t.Error("want RestrictedInput=false after next frame, got true")
+	}
+}
+
 // --- ヘルパー ---
 
 // newGameStateWithGrid はテスト用のカスタムグリッドを持つ GameState を構築する。

--- a/state/stage.go
+++ b/state/stage.go
@@ -1,17 +1,22 @@
 package state
 
-import "time"
+import (
+	"time"
+
+	"github.com/masahiro-kasatani/pacvim/input"
+)
 
 // Stage は1ステージの設定と状態を保持する。
 type Stage struct {
-	Level        int
-	MapPath      string
-	Grid         *Grid
-	HunterConfig EnemyConfig
-	GhostConfig  *EnemyConfig // ゴーストが存在しないステージでは nil
-	GameSpeed    time.Duration
-	Theme        string   // 学習テーマ（例: "Basic Movement"）
-	Commands     []string // このステージで練習するコマンドの説明（表示用）
+	Level          int
+	MapPath        string
+	Grid           *Grid
+	HunterConfig   EnemyConfig
+	GhostConfig    *EnemyConfig    // ゴーストが存在しないステージでは nil
+	GameSpeed      time.Duration
+	Theme          string          // 学習テーマ（例: "Basic Movement"）
+	Commands       []string        // このステージで練習するコマンドの説明（表示用）
+	RestrictedCmds []input.Command // このステージで使用できないコマンド
 }
 
 // Load はマップファイルを読み込み、Grid を設定して SpawnPoints を返す。
@@ -29,17 +34,18 @@ func (s *Stage) Load() (*SpawnPoints, error) {
 func InitStages() []Stage {
 	return []Stage{
 		{
-			Level:        1,
-			MapPath:      "files/stage/map01.txt",
-			HunterConfig: EnemyConfig{Builder: NewHunterBuilder()},
-			GameSpeed:    1250 * time.Millisecond,
-			Theme:        "Basic Movement",
+			Level:          1,
+			MapPath:        "files/stage/map01.txt",
+			HunterConfig:   EnemyConfig{Builder: NewHunterBuilder()},
+			GameSpeed:      1250 * time.Millisecond,
+			Theme:          "Basic Movement",
 			Commands: []string{
 				"h  move left",
 				"l  move right",
 				"j  move down",
 				"k  move up",
 			},
+			RestrictedCmds: []input.Command{},
 		},
 		{
 			Level:        2,
@@ -52,6 +58,10 @@ func InitStages() []Stage {
 				"w  move to next word",
 				"e  move to end of word",
 				"b  move to previous word",
+			},
+			RestrictedCmds: []input.Command{
+				input.CmdMoveLeft,
+				input.CmdMoveRight,
 			},
 		},
 		{
@@ -68,6 +78,7 @@ func InitStages() []Stage {
 				"gg  move to first line",
 				"G   move to last line  (NG: line N)",
 			},
+			RestrictedCmds: []input.Command{},
 		},
 		{
 			Level:        4,
@@ -81,6 +92,11 @@ func InitStages() []Stage {
 				";     repeat last find",
 				",     repeat last find (reverse)",
 			},
+			RestrictedCmds: []input.Command{
+				input.CmdWordForward,
+				input.CmdWordEnd,
+				input.CmdWordBack,
+			},
 		},
 		{
 			Level:        5,
@@ -93,6 +109,7 @@ func InitStages() []Stage {
 				"h/j/k/l  w/e/b  0/$/^",
 				"gg/G  f/t/;/,",
 			},
+			RestrictedCmds: []input.Command{},
 		},
 	}
 }


### PR DESCRIPTION
## Summary

- `Stage.RestrictedCmds []input.Command` フィールドを追加し、各ステージの封印コマンドを定義
  - 2面: `h` `l` を封印
  - 4面: `w` `e` `b` を封印
  - 1・3・5面: 封印なし
- `GameState.updatePlaying()` で封印コマンドを検出したら `Player.Apply()` を呼ばずにスキップ
- `GameState.RestrictedInput bool` フラグでフレーム単位の封印検出を renderer に伝達
- `renderer` で `RestrictedInput == true` のとき画面に「そのコマンドはこのステージでは使えません」を表示

## `go test ./state/... -v`

```
=== RUN   TestRestrictedCmdBlockedOnStage2
--- PASS: TestRestrictedCmdBlockedOnStage2 (0.00s)
=== RUN   TestRestrictedCmdAllowedOnStage2
--- PASS: TestRestrictedCmdAllowedOnStage2 (0.00s)
=== RUN   TestRestrictedCmdNotBlockedOnStage3
--- PASS: TestRestrictedCmdNotBlockedOnStage3 (0.00s)
=== RUN   TestRestrictedCmdNotBlockedOnStage1
--- PASS: TestRestrictedCmdNotBlockedOnStage1 (0.00s)
=== RUN   TestRestrictedInputFlagSet
--- PASS: TestRestrictedInputFlagSet (0.00s)
=== RUN   TestRestrictedInputFlagClearedNextFrame
--- PASS: TestRestrictedInputFlagClearedNextFrame (0.00s)
ok  	github.com/masahiro-kasatani/pacvim/state	(全 101 テスト PASS)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)