### PR TITLE
feat: ステージセレクト画面を追加

### DIFF
--- a/input/input.go
+++ b/input/input.go
@@ -38,6 +38,7 @@ const (
 	CmdLow                  // L
 	CmdWordEndBack          // ge
 	CmdQuit                 // q
+	CmdConfirm              // Enter
 )
 
 // キーリピートのタイミング定数（TPS=60 基準）
@@ -184,6 +185,8 @@ func (h *Handler) Read() (Command, rune) {
 			return CmdRepeatFindRev, 0
 		case inpututil.IsKeyJustPressed(ebiten.KeyQ):
 			return CmdQuit, 0
+		case inpututil.IsKeyJustPressed(ebiten.KeyEnter):
+			return CmdConfirm, 0
 		}
 	}
 

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -218,7 +218,7 @@ func (r *Renderer) drawStageSelectOverlay(screen *ebiten.Image, gs *state.GameSt
 	}
 
 	y += lineH
-	r.drawCharCentered(screen, "j/k: move   l: select", cx, y, colorHint)
+	r.drawCharCentered(screen, "j/k: move   Enter: select", cx, y, colorHint)
 	y += lineH
 	r.drawCharCentered(screen, "q: quit", cx, y, colorHint)
 }

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -66,6 +66,8 @@ func (r *Renderer) Draw(screen *ebiten.Image, gs *state.GameState) {
 	case state.PhaseOpening:
 		r.drawGame(screen, gs)
 		r.drawOpeningOverlay(screen)
+	case state.PhaseStageSelect:
+		r.drawStageSelectOverlay(screen, gs)
 	case state.PhaseReady:
 		r.drawGame(screen, gs)
 		r.drawReadyOverlay(screen, gs)
@@ -187,6 +189,38 @@ func (r *Renderer) drawOpeningOverlay(screen *ebiten.Image) {
 	r.drawCharCentered(screen, "Learn Vim by playing Pac-Man!", cx, cy-10, colorHint)
 	r.drawCharCentered(screen, "Press any key to start", cx, cy+16, colorStatusText)
 	r.drawCharCentered(screen, "q: quit", cx, cy+36, colorHint)
+}
+
+func (r *Renderer) drawStageSelectOverlay(screen *ebiten.Image, gs *state.GameState) {
+	vector.FillRect(screen, 0, 0, ScreenWidth, ScreenHeight, colorBackground, false)
+	cx := ScreenWidth / 2
+
+	const lineH = 20
+	stages := gs.Stages
+	// title(1) + gap(1) + stages(N) + gap(1) + hint(1) + quit(1)
+	totalLines := 2 + len(stages) + 3
+	startY := (ScreenHeight - totalLines*lineH) / 2
+
+	y := startY
+	r.drawCharCentered(screen, "Stage Select", cx, y, colorTitle)
+	y += lineH * 2
+
+	for i, s := range stages {
+		cursor := "  "
+		clr := colorHint
+		if i == gs.StageSelectIdx {
+			cursor = "▶ "
+			clr = colorStatusText
+		}
+		line := fmt.Sprintf("%s%d. %s", cursor, s.Level, s.Theme)
+		r.drawCharCentered(screen, line, cx, y, clr)
+		y += lineH
+	}
+
+	y += lineH
+	r.drawCharCentered(screen, "j/k: move   l: select", cx, y, colorHint)
+	y += lineH
+	r.drawCharCentered(screen, "q: quit", cx, y, colorHint)
 }
 
 func (r *Renderer) drawReadyOverlay(screen *ebiten.Image, gs *state.GameState) {

--- a/state/gamestate.go
+++ b/state/gamestate.go
@@ -134,7 +134,7 @@ func (gs *GameState) updateStageSelect(cmd input.Command) {
 		gs.StageSelectIdx = (gs.StageSelectIdx + 1) % n
 	case input.CmdMoveUp:
 		gs.StageSelectIdx = (gs.StageSelectIdx + n - 1) % n
-	case input.CmdMoveRight:
+	case input.CmdConfirm:
 		gs.StageIdx = gs.StageSelectIdx
 		_ = gs.loadStage()
 		gs.Phase = PhaseReady

--- a/state/gamestate.go
+++ b/state/gamestate.go
@@ -14,12 +14,13 @@ var ErrQuit = errors.New("quit")
 type GamePhase int
 
 const (
-	PhaseOpening  GamePhase = iota // 開幕画面（最初のキー入力待ち）
-	PhaseReady                     // 準備画面（ステージ開始前・ミス後）
-	PhasePlaying                   // プレイ中
-	PhaseDead                      // 死亡演出中（deadDuration フレーム後に PhaseReady へ遷移）
-	PhaseGameOver                  // ゲームオーバー
-	PhaseGameClear                 // 全ステージクリア
+	PhaseOpening     GamePhase = iota // 開幕画面（最初のキー入力待ち）
+	PhaseStageSelect                  // ステージセレクト画面
+	PhaseReady                        // 準備画面（ステージ開始前・ミス後）
+	PhasePlaying                      // プレイ中
+	PhaseDead                         // 死亡演出中（deadDuration フレーム後に PhaseReady へ遷移）
+	PhaseGameOver                     // ゲームオーバー
+	PhaseGameClear                    // 全ステージクリア
 )
 
 // deadDuration は PhaseDead の持続フレーム数（約1.5秒 @ TPS=60）。
@@ -27,14 +28,15 @@ const deadDuration = 90
 
 // GameState はゲーム全体の状態を保持する。
 type GameState struct {
-	Stages         []Stage
-	StageIdx       int
-	Player         *Player
-	Enemies        []Enemy
-	Life           int
-	EnemyTick      int
-	Phase          GamePhase
-	deadTimer      int  // PhaseDead の経過フレーム数
+	Stages          []Stage
+	StageIdx        int
+	StageSelectIdx  int  // ステージセレクト画面でのカーソル位置
+	Player          *Player
+	Enemies         []Enemy
+	Life            int
+	EnemyTick       int
+	Phase           GamePhase
+	deadTimer       int  // PhaseDead の経過フレーム数
 	RestrictedInput bool // 直前のフレームで封印コマンドが入力されたか
 }
 
@@ -110,7 +112,9 @@ func (gs *GameState) Update(cmd input.Command, ch rune) error {
 
 	switch gs.Phase {
 	case PhaseOpening:
-		gs.updateWaitKey(cmd, PhaseReady)
+		gs.updateWaitKey(cmd, PhaseStageSelect)
+	case PhaseStageSelect:
+		gs.updateStageSelect(cmd)
 	case PhaseReady:
 		gs.updateWaitKey(cmd, PhasePlaying)
 	case PhasePlaying:
@@ -119,6 +123,22 @@ func (gs *GameState) Update(cmd input.Command, ch rune) error {
 		gs.updateDead()
 	}
 	return nil
+}
+
+// updateStageSelect はステージセレクト画面の入力を処理する。
+// j/k でカーソル移動、l で選択して PhaseReady へ遷移する。
+func (gs *GameState) updateStageSelect(cmd input.Command) {
+	n := len(gs.Stages)
+	switch cmd {
+	case input.CmdMoveDown:
+		gs.StageSelectIdx = (gs.StageSelectIdx + 1) % n
+	case input.CmdMoveUp:
+		gs.StageSelectIdx = (gs.StageSelectIdx + n - 1) % n
+	case input.CmdMoveRight:
+		gs.StageIdx = gs.StageSelectIdx
+		_ = gs.loadStage()
+		gs.Phase = PhaseReady
+	}
 }
 
 // updateDead は PhaseDead のフレームを進め、deadDuration 経過後に PhaseReady へ遷移する。

--- a/state/gamestate_test.go
+++ b/state/gamestate_test.go
@@ -109,8 +109,8 @@ func TestUpdateOpeningStartsOnCommand(t *testing.T) {
 		t.Fatalf("NewGameState failed: %v", err)
 	}
 	_ = gs.Update(input.CmdMoveRight, 0)
-	if gs.Phase != PhaseReady {
-		t.Errorf("command should transition to PhaseReady, got %v", gs.Phase)
+	if gs.Phase != PhaseStageSelect {
+		t.Errorf("command should transition to PhaseStageSelect, got %v", gs.Phase)
 	}
 }
 
@@ -386,6 +386,85 @@ func TestStageAccessor(t *testing.T) {
 	}
 	if gs.Stage() != &gs.Stages[0] {
 		t.Error("Stage() should return pointer to current stage")
+	}
+}
+
+// --- PhaseStageSelect ---
+
+func TestStageSelectInitialCursor(t *testing.T) {
+	gs, err := NewGameState(3)
+	if err != nil {
+		t.Fatalf("NewGameState failed: %v", err)
+	}
+	if gs.StageSelectIdx != 0 {
+		t.Errorf("want StageSelectIdx=0, got %d", gs.StageSelectIdx)
+	}
+}
+
+func TestStageSelectMoveCursorDown(t *testing.T) {
+	gs, err := NewGameState(3)
+	if err != nil {
+		t.Fatalf("NewGameState failed: %v", err)
+	}
+	gs.Phase = PhaseStageSelect
+	_ = gs.Update(input.CmdMoveDown, 0)
+	if gs.StageSelectIdx != 1 {
+		t.Errorf("j: want StageSelectIdx=1, got %d", gs.StageSelectIdx)
+	}
+}
+
+func TestStageSelectMoveCursorUp(t *testing.T) {
+	gs, err := NewGameState(3)
+	if err != nil {
+		t.Fatalf("NewGameState failed: %v", err)
+	}
+	gs.Phase = PhaseStageSelect
+	gs.StageSelectIdx = 2
+	_ = gs.Update(input.CmdMoveUp, 0)
+	if gs.StageSelectIdx != 1 {
+		t.Errorf("k: want StageSelectIdx=1, got %d", gs.StageSelectIdx)
+	}
+}
+
+func TestStageSelectCursorWrapsDown(t *testing.T) {
+	gs, err := NewGameState(3)
+	if err != nil {
+		t.Fatalf("NewGameState failed: %v", err)
+	}
+	gs.Phase = PhaseStageSelect
+	gs.StageSelectIdx = len(gs.Stages) - 1
+	_ = gs.Update(input.CmdMoveDown, 0)
+	if gs.StageSelectIdx != 0 {
+		t.Errorf("j at last: want wrap to 0, got %d", gs.StageSelectIdx)
+	}
+}
+
+func TestStageSelectCursorWrapsUp(t *testing.T) {
+	gs, err := NewGameState(3)
+	if err != nil {
+		t.Fatalf("NewGameState failed: %v", err)
+	}
+	gs.Phase = PhaseStageSelect
+	gs.StageSelectIdx = 0
+	_ = gs.Update(input.CmdMoveUp, 0)
+	if gs.StageSelectIdx != len(gs.Stages)-1 {
+		t.Errorf("k at first: want wrap to last, got %d", gs.StageSelectIdx)
+	}
+}
+
+func TestStageSelectConfirm(t *testing.T) {
+	gs, err := NewGameState(3)
+	if err != nil {
+		t.Fatalf("NewGameState failed: %v", err)
+	}
+	gs.Phase = PhaseStageSelect
+	gs.StageSelectIdx = 2 // 3面を選択
+	_ = gs.Update(input.CmdMoveRight, 0)
+	if gs.Phase != PhaseReady {
+		t.Errorf("l: want PhaseReady, got %v", gs.Phase)
+	}
+	if gs.StageIdx != 2 {
+		t.Errorf("l: want StageIdx=2, got %d", gs.StageIdx)
 	}
 }
 

--- a/state/gamestate_test.go
+++ b/state/gamestate_test.go
@@ -459,12 +459,12 @@ func TestStageSelectConfirm(t *testing.T) {
 	}
 	gs.Phase = PhaseStageSelect
 	gs.StageSelectIdx = 2 // 3面を選択
-	_ = gs.Update(input.CmdMoveRight, 0)
+	_ = gs.Update(input.CmdConfirm, 0)
 	if gs.Phase != PhaseReady {
-		t.Errorf("l: want PhaseReady, got %v", gs.Phase)
+		t.Errorf("Enter: want PhaseReady, got %v", gs.Phase)
 	}
 	if gs.StageIdx != 2 {
-		t.Errorf("l: want StageIdx=2, got %d", gs.StageIdx)
+		t.Errorf("Enter: want StageIdx=2, got %d", gs.StageIdx)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `PhaseStageSelect` を追加し、Opening → StageSelect → Ready の順で遷移するよう変更
- `GameState.StageSelectIdx` でカーソル位置を管理
- j/k でカーソル移動（端でラップアラウンド）、l で選択して PhaseReady へ
- renderer に `drawStageSelectOverlay` を追加（ステージ一覧・カーソル・操作ヒントを表示）

## 操作

| キー | 動作 |
|---|---|
| `j` | カーソルを下へ |
| `k` | カーソルを上へ |
| `l` | ステージを選択して開始 |
| `q` | 終了 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)