### PR TITLE
fix: 封印コマンドのメッセージをステータスバーに2秒間表示

### DIFF
--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -73,9 +73,6 @@ func (r *Renderer) Draw(screen *ebiten.Image, gs *state.GameState) {
 		r.drawReadyOverlay(screen, gs)
 	case state.PhasePlaying:
 		r.drawGame(screen, gs)
-		if gs.RestrictedInput {
-			r.drawRestrictedMessage(screen)
-		}
 	case state.PhaseDead:
 		r.drawGame(screen, gs)
 		r.drawDeadOverlay(screen)
@@ -177,6 +174,12 @@ func (r *Renderer) drawStatusBar(screen *ebiten.Image, gs *state.GameState) {
 	text := fmt.Sprintf("  Level: %d    Score: %d/%d    Life: %d",
 		stage.Level, gs.Player.Score, gs.Player.TargetScore, gs.Life)
 	r.drawChar(screen, text, 4, statusBarY+15, colorStatusText)
+
+	if gs.RestrictedMsgFrames > 0 {
+		msg := "Command not available in this stage"
+		w, _ := textv2.Measure(msg, r.face, 0)
+		r.drawChar(screen, msg, ScreenWidth-int(w)-8, statusBarY+15, colorTitle)
+	}
 }
 
 // --- オーバーレイ ---
@@ -251,12 +254,6 @@ func (r *Renderer) drawReadyOverlay(screen *ebiten.Image, gs *state.GameState) {
 	r.drawCharCentered(screen, "Press any key to start", cx, y, colorStatusText)
 	y += lineH
 	r.drawCharCentered(screen, "q: quit", cx, y, colorHint)
-}
-
-func (r *Renderer) drawRestrictedMessage(screen *ebiten.Image) {
-	cx := ScreenWidth / 2
-	cy := ScreenHeight/2 - 30
-	r.drawCharCentered(screen, "That command is not available in this stage.", cx, cy, colorTitle)
 }
 
 func (r *Renderer) drawDeadOverlay(screen *ebiten.Image) {

--- a/state/gamestate.go
+++ b/state/gamestate.go
@@ -37,7 +37,7 @@ type GameState struct {
 	EnemyTick       int
 	Phase           GamePhase
 	deadTimer       int  // PhaseDead の経過フレーム数
-	RestrictedInput bool // 直前のフレームで封印コマンドが入力されたか
+	RestrictedMsgFrames int // 封印コマンドのフィードバックメッセージの残り表示フレーム数
 }
 
 // NewGameState は初期状態の GameState を生成する。
@@ -168,11 +168,16 @@ func (gs *GameState) isRestricted(cmd input.Command) bool {
 	return false
 }
 
+// restrictedMsgDuration は封印コマンドメッセージの表示フレーム数（約2秒 @ TPS=60）。
+const restrictedMsgDuration = 120
+
 // updatePlaying はプレイ中の更新処理。
 func (gs *GameState) updatePlaying(cmd input.Command, ch rune) {
-	gs.RestrictedInput = false
+	if gs.RestrictedMsgFrames > 0 {
+		gs.RestrictedMsgFrames--
+	}
 	if cmd != input.CmdNone && gs.isRestricted(cmd) {
-		gs.RestrictedInput = true
+		gs.RestrictedMsgFrames = restrictedMsgDuration
 		return
 	}
 	gs.Player.Apply(cmd, ch, gs.Stage(), gs.Enemies)

--- a/state/gamestate_test.go
+++ b/state/gamestate_test.go
@@ -549,8 +549,8 @@ func TestRestrictedCmdNotBlockedOnStage1(t *testing.T) {
 	}
 }
 
-// TestRestrictedInputFlagSet: 封印コマンドを入力したとき RestrictedInput が true になる。
-func TestRestrictedInputFlagSet(t *testing.T) {
+// TestRestrictedMsgFramesSet: 封印コマンドを入力したとき RestrictedMsgFrames が正の値になる。
+func TestRestrictedMsgFramesSet(t *testing.T) {
 	gs := newGameStateAtStage(1, []string{
 		"+++++",
 		"+   +",
@@ -558,23 +558,24 @@ func TestRestrictedInputFlagSet(t *testing.T) {
 	}, 3)
 	gs.Player.X = 3
 	_ = gs.Update(input.CmdMoveLeft, 0) // 2面では封印
-	if !gs.RestrictedInput {
-		t.Error("want RestrictedInput=true after restricted cmd, got false")
+	if gs.RestrictedMsgFrames <= 0 {
+		t.Errorf("want RestrictedMsgFrames>0 after restricted cmd, got %d", gs.RestrictedMsgFrames)
 	}
 }
 
-// TestRestrictedInputFlagClearedNextFrame: 次のフレームで RestrictedInput がリセットされる。
-func TestRestrictedInputFlagClearedNextFrame(t *testing.T) {
+// TestRestrictedMsgFramesCountsDown: フレームごとに RestrictedMsgFrames が減少する。
+func TestRestrictedMsgFramesCountsDown(t *testing.T) {
 	gs := newGameStateAtStage(1, []string{
 		"+++++",
 		"+   +",
 		"+++++",
 	}, 3)
 	gs.Player.X = 3
-	_ = gs.Update(input.CmdMoveLeft, 0) // 封印コマンド → true
-	_ = gs.Update(input.CmdNone, 0)     // 次フレーム → false
-	if gs.RestrictedInput {
-		t.Error("want RestrictedInput=false after next frame, got true")
+	_ = gs.Update(input.CmdMoveLeft, 0) // 封印コマンド → フレーム数セット
+	first := gs.RestrictedMsgFrames
+	_ = gs.Update(input.CmdNone, 0) // 次フレーム → 1減る
+	if gs.RestrictedMsgFrames != first-1 {
+		t.Errorf("want RestrictedMsgFrames=%d, got %d", first-1, gs.RestrictedMsgFrames)
 	}
 }
 


### PR DESCRIPTION
## 変更内容

- `RestrictedInput bool` を `RestrictedMsgFrames int` に変更
- 封印コマンド入力時に 120 フレーム（約2秒）のカウントダウンを開始
- 各フレームで 1 ずつ減算し、0 になるとメッセージ非表示
- 表示場所を画面中央オーバーレイ（点滅の原因）から**ステータスバー右端**に変更

## Before / After

| | Before | After |
|---|---|---|
| 表示場所 | 画面中央（ゲームに重なる） | ステータスバー右端 |
| 表示時間 | 1フレーム（点滅） | 約2秒 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)