### PR TITLE
fix: 1G 入力時のフリーズバグを修正

### DIFF
--- a/input/input.go
+++ b/input/input.go
@@ -87,6 +87,12 @@ func (h *Handler) Read() (Command, rune) {
 			h.prevG = false
 			return CmdWordEndBack, 0
 		}
+		// G キーが Shift より 1 フレーム先に検出された場合、次フレームで
+		// Shift+G として判定できるよう IsKeyPressed で確認してフリーズを防ぐ。
+		if shift && ebiten.IsKeyPressed(ebiten.KeyG) {
+			h.prevG = false
+			return CmdFileBottom, 0
+		}
 		return CmdNone, 0
 	}
 


### PR DESCRIPTION
## 原因

`prevG` フラグ（`g` キー入力後の待機状態）が解除されずにフリーズする問題を修正。

### 再現パス

1. `1` を押す → `inputNum=1` に蓄積
2. `G`（Shift+G）を押す際、**G キーが Shift より 1 フレーム先に検出**される
   - 1フレーム目: Shift なしの `g` として検出 → `prevG=true`
   - 2フレーム目以降: prevG モード内で `!shift && IsKeyJustPressed(G)` が false → `CmdNone`、`prevG` は true のまま
3. 以降すべてのキー入力が無視されてフリーズ

### 修正内容

prevG モード内で `shift && ebiten.IsKeyPressed(KeyG)`（G が押し続けられていて Shift も押されている）を検出した場合に `prevG` を解除して `CmdFileBottom` を返すようにした。

`IsKeyJustPressed` ではなく `IsKeyPressed` を使うことで、G を押したまま Shift を追加で押すタイミングのずれに対応している。

## Test plan

- [ ] `1G` を入力してフリーズしないことを確認
- [ ] `G`（カウントなし）が最終行に移動することを確認
- [ ] `gg` が最初の行に移動することを確認
- [ ] `ge` が前のワード末尾に移動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)