### PR TITLE
fix: 行番号の縦位置をタイル内でセンタリング

### DIFF
--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -187,12 +187,14 @@ func (r *Renderer) drawStatusBar(screen *ebiten.Image, gs *state.GameState) {
 	stage := gs.Stage()
 	text := fmt.Sprintf("  Level: %d    Score: %d/%d    Life: %d",
 		stage.Level, gs.Player.Score, gs.Player.TargetScore, gs.Life)
-	r.drawChar(screen, text, 4, statusBarY+28, colorStatusText)
+	_, th := textv2.Measure(text, r.face, 0)
+	textY := statusBarY + (statusBarH-int(th))/2
+	r.drawChar(screen, text, 4, textY, colorStatusText)
 
 	if gs.RestrictedMsgFrames > 0 {
 		msg := "Command not available in this stage"
 		w, _ := textv2.Measure(msg, r.face, 0)
-		r.drawChar(screen, msg, ScreenWidth-int(w)-8, statusBarY+28, colorTitle)
+		r.drawChar(screen, msg, ScreenWidth-int(w)-8, textY, colorTitle)
 	}
 }
 

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -138,7 +138,8 @@ func (r *Renderer) drawLineNumbers(screen *ebiten.Image, grid *state.Grid) {
 	for y := 0; y < grid.Height; y++ {
 		_, sy := gridToScreen(0, y)
 		num := fmt.Sprintf("%2d", y+1)
-		r.drawChar(screen, num, 2, sy+TileSize/2+7, colorLineNum)
+		_, h := textv2.Measure(num, r.face, 0)
+		r.drawChar(screen, num, 2, sy+(TileSize-int(h))/2, colorLineNum)
 	}
 }
 

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -137,9 +137,9 @@ func (r *Renderer) drawGrid(screen *ebiten.Image, grid *state.Grid) {
 func (r *Renderer) drawLineNumbers(screen *ebiten.Image, grid *state.Grid) {
 	for y := 0; y < grid.Height; y++ {
 		_, sy := gridToScreen(0, y)
-		num := fmt.Sprintf("%2d", y+1)
-		_, h := textv2.Measure(num, r.face, 0)
-		r.drawChar(screen, num, 2, sy+(TileSize-int(h))/2, colorLineNum)
+		num := fmt.Sprintf("%d", y+1)
+		w, h := textv2.Measure(num, r.face, 0)
+		r.drawChar(screen, num, OffsetX-int(w)-4, sy+(TileSize-int(h))/2, colorLineNum)
 	}
 }
 


### PR DESCRIPTION
## 概要

フォントサイズ変更（PR #28）後に行番号の縦位置がずれていた問題を修正。

マジックナンバー `sy+TileSize/2+7` の代わりに `textv2.Measure` で実際のフォント高さを取得し、`(TileSize-h)/2` でタイル内に垂直センタリングする。

## Test plan

- [ ] 行番号がグリッドの各行と縦位置で揃って表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)