### PR TITLE
feat: ステータスバーに入力中のキー列を表示

### DIFF
--- a/game.go
+++ b/game.go
@@ -51,6 +51,11 @@ func (g *Game) Update() error {
 		}
 	}
 
+	// 入力中のキー列をステータスバー表示用に更新する
+	if g.gs.Player != nil {
+		g.gs.InputBuffer = g.gs.Player.InputNumDisplay() + g.in.PendingDisplay()
+	}
+
 	return nil
 }
 

--- a/input/input.go
+++ b/input/input.go
@@ -58,6 +58,27 @@ type Handler struct {
 	repeatFrames int        // repeatKey を押し続けたフレーム数
 }
 
+// PendingDisplay は現在の入力待ち状態を表示用文字列で返す。
+// prevG モード中は "g"、awaitChar モード中は "f"/"F"/"t"/"T" を返す。
+func (h *Handler) PendingDisplay() string {
+	if h.prevG {
+		return "g"
+	}
+	if h.awaitChar {
+		switch h.pendingCmd {
+		case CmdFindForward:
+			return "f"
+		case CmdFindBack:
+			return "F"
+		case CmdTillForward:
+			return "t"
+		case CmdTillBack:
+			return "T"
+		}
+	}
+	return ""
+}
+
 // Read は1フレーム分のキー入力を読み取り、(Command, rune) を返す。
 // CmdNum のとき rune は押された数字文字（0〜9）。0 単独か数字蓄積中かの判断は state 側で行う。
 // CmdFindForward/Back/TillForward/Back のとき rune は対象文字。

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -191,6 +191,12 @@ func (r *Renderer) drawStatusBar(screen *ebiten.Image, gs *state.GameState) {
 	textY := statusBarY + (statusBarH-int(th))/2
 	r.drawChar(screen, text, 4, textY, colorStatusText)
 
+	// 入力中のキー列を中央に表示
+	if gs.InputBuffer != "" {
+		iw, _ := textv2.Measure(gs.InputBuffer, r.face, 0)
+		r.drawChar(screen, gs.InputBuffer, ScreenWidth/2-int(iw)/2, textY, colorStatusText)
+	}
+
 	if gs.RestrictedMsgFrames > 0 {
 		msg := "Command not available in this stage"
 		w, _ := textv2.Measure(msg, r.face, 0)

--- a/state/gamestate.go
+++ b/state/gamestate.go
@@ -35,9 +35,10 @@ type GameState struct {
 	Enemies         []Enemy
 	Life            int
 	EnemyTick       int
-	Phase           GamePhase
-	deadTimer       int  // PhaseDead の経過フレーム数
+	Phase               GamePhase
+	deadTimer           int // PhaseDead の経過フレーム数
 	RestrictedMsgFrames int // 封印コマンドのフィードバックメッセージの残り表示フレーム数
+	InputBuffer         string // ステータスバーに表示する入力中のキー列
 }
 
 // NewGameState は初期状態の GameState を生成する。

--- a/state/player.go
+++ b/state/player.go
@@ -1,6 +1,10 @@
 package state
 
-import "github.com/masahiro-kasatani/pacvim/input"
+import (
+	"fmt"
+
+	"github.com/masahiro-kasatani/pacvim/input"
+)
 
 // PlayerState はプレイヤーの生死状態を表す。
 type PlayerState int
@@ -113,6 +117,14 @@ func (p *Player) Apply(cmd input.Command, ch rune, stage *Stage, enemies []Enemy
 	}
 
 	p.resetInput()
+}
+
+// InputNumDisplay はカウントプレフィックスの表示用文字列を返す。入力がなければ空文字。
+func (p *Player) InputNumDisplay() string {
+	if p.inputNum == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d", p.inputNum)
 }
 
 // repeatCount はカウント入力の回数を返す。入力がなければ 1。


### PR DESCRIPTION
## 概要

カウントプレフィックスや `g`/`f`/`t` などの入力待ち状態をステータスバー中央にリアルタイム表示する。

## 表示例

| 操作 | 表示 |
|---|---|
| `3` を押した後 | `3` |
| `3w` を入力中（w 待ち）| `3` |
| `g` を押した後（gg/ge 待ち）| `g` |
| `f` を押した後（文字待ち）| `f` |
| `3f` を押した後（文字待ち）| `3f` |

コマンド確定後は即座にクリアされる。

## 変更内容

- `input.Handler.PendingDisplay()`: prevG・awaitChar 状態を文字列化
- `state.Player.InputNumDisplay()`: カウントプレフィックスを文字列化
- `state.GameState.InputBuffer`: 表示用バッファ
- `game.go`: 毎フレーム `InputBuffer` を更新
- `renderer`: ステータスバー中央に `InputBuffer` を描画

併せて行番号の右揃えとステータスバーテキストの垂直センタリングも適用（PR #30 相当）。

## Test plan

- [ ] `3` を押すとステータスバー中央に `3` が表示される
- [ ] `g` を押すと `g` が表示され、`gg` 確定後に消える
- [ ] `f` を押すと `f` が表示され、文字入力後に消える
- [ ] `3f` と押すと `3f` が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)