### PR TITLE
fix: f/t コマンドがカウントを無視していた問題を修正

### DIFF
--- a/state/player.go
+++ b/state/player.go
@@ -93,26 +93,26 @@ func (p *Player) Apply(cmd input.Command, ch rune, stage *Stage, enemies []Enemy
 
 	case input.CmdFindForward:
 		p.lastFind = &findCmd{isTill: false, forward: true, ch: ch}
-		p.applyFind(ch, true, false, stage, enemies)
+		p.applyFind(ch, true, false, p.repeatCount(), stage, enemies)
 	case input.CmdFindBack:
 		p.lastFind = &findCmd{isTill: false, forward: false, ch: ch}
-		p.applyFind(ch, false, false, stage, enemies)
+		p.applyFind(ch, false, false, p.repeatCount(), stage, enemies)
 	case input.CmdTillForward:
 		p.lastFind = &findCmd{isTill: true, forward: true, ch: ch}
-		p.applyFind(ch, true, true, stage, enemies)
+		p.applyFind(ch, true, true, p.repeatCount(), stage, enemies)
 	case input.CmdTillBack:
 		p.lastFind = &findCmd{isTill: true, forward: false, ch: ch}
-		p.applyFind(ch, false, true, stage, enemies)
+		p.applyFind(ch, false, true, p.repeatCount(), stage, enemies)
 
 	case input.CmdRepeatFind:
 		if p.lastFind != nil {
 			f := p.lastFind
-			p.applyFind(f.ch, f.forward, f.isTill, stage, enemies)
+			p.applyFind(f.ch, f.forward, f.isTill, p.repeatCount(), stage, enemies)
 		}
 	case input.CmdRepeatFindRev:
 		if p.lastFind != nil {
 			f := p.lastFind
-			p.applyFind(f.ch, !f.forward, f.isTill, stage, enemies)
+			p.applyFind(f.ch, !f.forward, f.isTill, p.repeatCount(), stage, enemies)
 		}
 	}
 
@@ -360,18 +360,23 @@ func charMatchesCell(ch rune, cell Cell) bool {
 
 // applyFind は f/F/t/T の検索・移動ロジックを実行する。
 // forward=true で右方向、isTill=true で1マス手前止まり（t/T 挙動）。
-func (p *Player) applyFind(ch rune, forward bool, isTill bool, stage *Stage, enemies []Enemy) {
+// count は何番目のマッチへ移動するかを指定する（3fo なら count=3）。
+func (p *Player) applyFind(ch rune, forward bool, isTill bool, count int, stage *Stage, enemies []Enemy) {
 	dx := 1
 	if !forward {
 		dx = -1
 	}
 
-	// 現在行で対象文字を検索
+	// 現在行で count 番目のマッチを検索
+	found := 0
 	targetX := -1
 	for x := p.X + dx; x >= 0 && x < stage.Grid.Width; x += dx {
 		if charMatchesCell(ch, stage.Grid.At(x, p.Y)) {
-			targetX = x
-			break
+			found++
+			if found == count {
+				targetX = x
+				break
+			}
 		}
 	}
 	if targetX == -1 {

--- a/state/player_test.go
+++ b/state/player_test.go
@@ -737,6 +737,57 @@ func TestRepeatFindNilLastFind(t *testing.T) {
 	}
 }
 
+// TestFindForwardWithCount: 3fo で3番目の o にジャンプする。
+func TestFindForwardWithCount(t *testing.T) {
+	// x=2,4,6,8 に o がある
+	stage := newStage([]string{
+		"++++++++++",
+		"+ o o o o+",
+		"++++++++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive, TargetScore: 99}
+	p.Apply(input.CmdNum, '3', stage, nil)
+	p.Apply(input.CmdFindForward, 'o', stage, nil)
+	// 3番目の o は x=6
+	if p.X != 6 {
+		t.Errorf("3fo: want X=6, got X=%d", p.X)
+	}
+}
+
+// TestFindBackWithCount: 3Fo で左方向3番目の o にジャンプする。
+func TestFindBackWithCount(t *testing.T) {
+	// x=2,4,6,8 に o がある。プレイヤーは x=9 からスタート。
+	stage := newStage([]string{
+		"++++++++++",
+		"+ o o o o+",
+		"++++++++++",
+	})
+	p := &Player{X: 9, Y: 1, State: PlayerAlive, TargetScore: 99}
+	p.Apply(input.CmdNum, '3', stage, nil)
+	p.Apply(input.CmdFindBack, 'o', stage, nil)
+	// 左方向3番目の o は x=4
+	if p.X != 4 {
+		t.Errorf("3Fo: want X=4, got X=%d", p.X)
+	}
+}
+
+// TestRepeatFindWithCount: 2; で2番目のマッチへ移動する。
+func TestRepeatFindWithCount(t *testing.T) {
+	// x=2,4,6,8 に o がある
+	stage := newStage([]string{
+		"++++++++++",
+		"+ o o o o+",
+		"++++++++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive, TargetScore: 99}
+	p.Apply(input.CmdFindForward, 'o', stage, nil) // fo: x=2
+	p.Apply(input.CmdNum, '2', stage, nil)
+	p.Apply(input.CmdRepeatFind, 0, stage, nil) // 2;: x=2から右2番目のo → x=6
+	if p.X != 6 {
+		t.Errorf("2;: want X=6, got X=%d", p.X)
+	}
+}
+
 // TestFindWalkDiesOnPoison: fo は walk なので経路上に毒があれば死亡する。
 func TestFindWalkDiesOnPoison(t *testing.T) {
 	stage := newStage([]string{


### PR DESCRIPTION
## 概要

`3fo` が1番目の `o` にしかジャンプしない問題を修正。

## 修正内容

`applyFind` に `count` 引数を追加し、N 番目のマッチまで検索するよう変更。`f/F/t/T` および `;/,` のリピートコマンドもカウントに対応。

**例:** `ooooo` で先頭にいるとき `3fo` → 4番目の `o` にジャンプ

## Test plan

- [ ] `3fo` で3番目の `o` にジャンプすることを確認
- [ ] `2;` で2番目のマッチへ移動することを確認
- [ ] カウントなしの `fo` が従来通り動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)