### PR TITLE
fix: 取得済みりんごを fo の検索対象に含める

### DIFF
--- a/state/player.go
+++ b/state/player.go
@@ -349,11 +349,11 @@ func (p *Player) gotoLastLine(stage *Stage, enemies []Enemy) {
 func charMatchesCell(ch rune, cell Cell) bool {
 	switch ch {
 	case charApple: // 'o'
-		return cell.Kind == CellApple
+		return cell.Kind == CellApple || cell.Kind == CellAppleEaten
 	case charPoison: // 'X'
 		return cell.Kind == CellPoison
 	case ' ':
-		return cell.Kind == CellSpace || cell.Kind == CellAppleEaten
+		return cell.Kind == CellSpace
 	}
 	return false
 }

--- a/state/player_test.go
+++ b/state/player_test.go
@@ -806,6 +806,52 @@ func TestFindWalkDiesOnPoison(t *testing.T) {
 	}
 }
 
+// TestFindAppleEatenMatchesO: 取得済みりんご（CellAppleEaten）も fo でヒットする。
+func TestFindAppleEatenMatchesO(t *testing.T) {
+	stage := newStage([]string{
+		"++++++++",
+		"+ o o o+",
+		"++++++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive, TargetScore: 99}
+	// 最初の fo で x=2 のりんごを取得（CellAppleEaten になる）
+	p.Apply(input.CmdFindForward, 'o', stage, nil)
+	if p.X != 2 {
+		t.Fatalf("fo: want X=2, got X=%d", p.X)
+	}
+	// x=2 が CellAppleEaten になっていることを確認
+	if stage.Grid.At(2, 1).Kind != CellAppleEaten {
+		t.Fatalf("want CellAppleEaten at x=2")
+	}
+	// x=4 へ移動してから Fo で左方向検索 → 取得済みの x=2 もヒットするはず
+	p.Apply(input.CmdFindForward, 'o', stage, nil) // x=4
+	p.Apply(input.CmdFindBack, 'o', stage, nil)    // Fo: 左方向 → x=2（取得済み）
+	if p.X != 2 {
+		t.Errorf("Fo on eaten apple: want X=2, got X=%d", p.X)
+	}
+}
+
+// TestFindSpaceDoesNotMatchAppleEaten: f<space> は取得済みりんごにヒットしない。
+func TestFindSpaceDoesNotMatchAppleEaten(t *testing.T) {
+	stage := newStage([]string{
+		"++++++++",
+		"+ o   o+",
+		"++++++++",
+	})
+	p := &Player{X: 1, Y: 1, State: PlayerAlive, TargetScore: 99}
+	// fo で x=2 を取得（CellAppleEaten）
+	p.Apply(input.CmdFindForward, 'o', stage, nil)
+	if p.X != 2 {
+		t.Fatalf("fo: want X=2, got X=%d", p.X)
+	}
+	// x=1 に戻って f<space> → 取得済みの x=2 はスペースではないので x=3 にヒット
+	p.X = 1
+	p.Apply(input.CmdFindForward, ' ', stage, nil)
+	if p.X != 3 {
+		t.Errorf("f<space> should skip AppleEaten: want X=3, got X=%d", p.X)
+	}
+}
+
 // TestCountResetAfterCommand: コマンド実行後にカウントがリセットされ、次のコマンドに引き継がれない。
 func TestCountResetAfterCommand(t *testing.T) {
 	stage := newStage([]string{


### PR DESCRIPTION
## 概要

`fo` で取得済みりんご（黄色）がヒットしない問題を修正。

## 変更内容

`charMatchesCell` を修正：

| 入力文字 | 変更前 | 変更後 |
|---|---|---|
| `'o'` | `CellApple` のみ | `CellApple` + `CellAppleEaten` |
| `' '` | `CellSpace` + `CellAppleEaten` | `CellSpace` のみ |

## 背景

マップはテキストファイルの比喩。取得済みりんごは黄色で表示されても `'o'` 文字として存在し続けるべき（`w/e/b` が `CellAppleEaten` をワード文字として扱っているのと一貫性を持たせる）。

## Test plan

- [ ] `fo` で取得済みりんご（黄色）にもヒットすることを確認
- [ ] `f<space>` が取得済みりんごをスキップすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)